### PR TITLE
SHRINKRES-87: PackagingType is no longer an enum

### DIFF
--- a/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/PackagingType.java
+++ b/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/PackagingType.java
@@ -16,29 +16,34 @@
  */
 package org.jboss.shrinkwrap.resolver.api.maven;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
 
 /**
  * Represents the valid values for the "packaging" portion of a {@link MavenCoordinate}
  *
  * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
-public enum PackagingType {
-    POM("pom"), JAR("jar"), MAVEN_PLUGIN("maven-plugin"), EJB("ejb"), WAR("war"), EAR("ear"), RAR("rar"), PAR("par");
+public final class PackagingType {
+
+    public static final PackagingType POM = PackagingType.of("pom");
+    public static final PackagingType JAR = PackagingType.of("jar");
+    public static final PackagingType MAVEN_PLUGIN = PackagingType.of("maven-plugin");
+    public static final PackagingType EJB = PackagingType.of("ejb");
+    public static final PackagingType WAR = PackagingType.of("war");
+    public static final PackagingType EAR = PackagingType.of("ear");
+    public static final PackagingType RAR = PackagingType.of("rar");
+    public static final PackagingType PAR = PackagingType.of("par");
 
     private final String value;
 
-    PackagingType(final String value) {
+    private PackagingType(final String value) {
         this.value = value;
     }
 
     /**
      * Returns the canonical {@link String} value of this {@link PackagingType}
      *
-     * @see java.lang.Enum#toString()
      */
     @Override
     public String toString() {
@@ -46,34 +51,45 @@ public enum PackagingType {
     }
 
     /**
-     * Maps a string to PackagingType
+     * Builds a {@link PackagingType} object
      *
      * @param typeName
      *            String name of the packaging type
      * @return Corresponding PackagingType object
      * @throws IllegalArgumentException
-     *             Thrown if typeName is {@code null}, empty or does not represent a valid packaging type
+     *             Thrown if typeName is {@code null} or empty
      */
-    public static PackagingType fromPackagingType(String typeName) throws IllegalArgumentException {
+    public static PackagingType of(String typeName) throws IllegalArgumentException {
 
         if (typeName == null || typeName.length() == 0) {
             throw new IllegalArgumentException("Packaging type must not be null nor empty.");
         }
-
-        PackagingType pt = PACKAGING_NAME_CACHE.get(typeName);
-        if (pt == null) {
-            throw new IllegalArgumentException("Packaging type " + typeName + " is not supported.");
-        }
-        return pt;
+        return new PackagingType(typeName);
     }
 
-    private static final Map<String, PackagingType> PACKAGING_NAME_CACHE = new HashMap<String, PackagingType>() {
-        private static final long serialVersionUID = 1L;
-        {
-            for (PackagingType packaging : PackagingType.values()) {
-                this.put(packaging.value, packaging);
-            }
-        }
-    };
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        PackagingType other = (PackagingType) obj;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
+    }
 
 }

--- a/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/coordinate/MavenCoordinateImpl.java
+++ b/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/coordinate/MavenCoordinateImpl.java
@@ -140,26 +140,23 @@ class MavenCoordinateImpl extends MavenGABaseImpl implements MavenCoordinate {
      */
     @Override
     public boolean equals(final Object obj) {
-        if (this == obj) {
+        if (this == obj)
             return true;
-        }
-        if (!super.equals(obj)) {
+        if (!super.equals(obj))
             return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (getClass() != obj.getClass())
             return false;
-        }
         MavenCoordinateImpl other = (MavenCoordinateImpl) obj;
         if (classifier == null) {
-            if (other.classifier != null) {
+            if (other.classifier != null)
                 return false;
-            }
-        } else if (!classifier.equals(other.classifier)) {
+        } else if (!classifier.equals(other.classifier))
             return false;
-        }
-        if (packaging != other.packaging) {
+        if (packaging == null) {
+            if (other.packaging != null)
+                return false;
+        } else if (!packaging.equals(other.packaging))
             return false;
-        }
         return true;
     }
 

--- a/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/coordinate/MavenCoordinates.java
+++ b/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/coordinate/MavenCoordinates.java
@@ -191,7 +191,7 @@ public final class MavenCoordinates {
             assert type != null : "Should not be fed a null type via internals (regardless of user input)";
             PackagingType parsedPackagingType = null;
             try {
-                parsedPackagingType = PackagingType.fromPackagingType(type);
+                parsedPackagingType = PackagingType.of(type);
             } catch (final IllegalArgumentException iae) {
                 // Exception translate
                 throw new CoordinateParseException(iae.getMessage());

--- a/api-maven/src/test/java/org/jboss/shrinkwrap/resolver/api/maven/coordinate/MavenCoordinatesTestCase.java
+++ b/api-maven/src/test/java/org/jboss/shrinkwrap/resolver/api/maven/coordinate/MavenCoordinatesTestCase.java
@@ -46,11 +46,6 @@ public class MavenCoordinatesTestCase {
 
     }
 
-    @Test(expected = CoordinateParseException.class)
-    public void invalidPackagingType() {
-        MavenCoordinates.createCoordinate("groupId:artifactId:invalidPackagingType:classifier:version");
-    }
-
     @Test
     public void fullProperties() {
         final MavenCoordinate coordinate = MavenCoordinates

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenResolvedArtifactImpl.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenResolvedArtifactImpl.java
@@ -75,7 +75,7 @@ public class MavenResolvedArtifactImpl implements MavenResolvedArtifact {
     static MavenResolvedArtifact fromArtifact(final Artifact artifact) {
         final MavenCoordinate mavenCoordinate = MavenCoordinates.createCoordinate(artifact.getGroupId(),
                 artifact.getArtifactId(), artifact.getBaseVersion(),
-                PackagingType.fromPackagingType(artifact.getExtension()), artifact.getClassifier());
+                PackagingType.of(artifact.getExtension()), artifact.getClassifier());
 
         return new MavenResolvedArtifactImpl(mavenCoordinate, artifact.getVersion(), artifact.isSnapshot(),
                 artifact.getExtension(), artifactToFile(artifact));

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/convert/MavenConverter.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/convert/MavenConverter.java
@@ -107,7 +107,7 @@ public class MavenConverter {
     public static MavenDependency fromDependency(final Dependency dependency) {
         final Artifact artifact = dependency.getArtifact();
         final MavenCoordinate coordinate = MavenCoordinates.createCoordinate(artifact.getGroupId(),
-            artifact.getArtifactId(), artifact.getVersion(), PackagingType.fromPackagingType(artifact.getExtension()),
+            artifact.getArtifactId(), artifact.getVersion(), PackagingType.of(artifact.getExtension()),
             artifact.getClassifier());
         final MavenDependency result = MavenDependencies.createDependency(coordinate,
             ScopeType.fromScopeType(dependency.getScope()), dependency.isOptional(),
@@ -147,7 +147,7 @@ public class MavenConverter {
         }
 
         final MavenCoordinate coordinate = MavenCoordinates.createCoordinate(artifact.getGroupId(),
-            artifact.getArtifactId(), artifact.getVersion(), PackagingType.fromPackagingType(artifact.getExtension()),
+            artifact.getArtifactId(), artifact.getVersion(), PackagingType.of(artifact.getExtension()),
             artifact.getClassifier());
         final MavenDependency result = MavenDependencies.createDependency(coordinate,
             ScopeType.fromScopeType(dependency.getScope()), dependency.isOptional(),


### PR DESCRIPTION
This is the least intrusive change I could think of. 

Probably the best way would be to remove this class and use String instead, but I'll leave that as an exercise for the merger :)
