### PR TITLE
setting system properties to allow interpolation in "fromFile" config

### DIFF
--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/task/ConfigureSettingsFromFileTask.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/task/ConfigureSettingsFromFileTask.java
@@ -19,6 +19,7 @@ package org.jboss.shrinkwrap.resolver.impl.maven.task;
 import java.io.File;
 
 import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuildingRequest;
 import org.jboss.shrinkwrap.resolver.api.InvalidConfigurationFileException;
 import org.jboss.shrinkwrap.resolver.impl.maven.MavenWorkingSession;
 
@@ -64,8 +65,10 @@ public class ConfigureSettingsFromFileTask implements MavenWorkingSessionTask {
             throw new InvalidConfigurationFileException(e.getMessage());
         }
 
-        final MavenWorkingSession newSession = session.execute(new DefaultSettingsBuildingRequest()
-            .setUserSettingsFile(settingsXmlFile));
+        final SettingsBuildingRequest request = new DefaultSettingsBuildingRequest()
+            .setSystemProperties(System.getProperties())
+            .setUserSettingsFile(settingsXmlFile);
+        final MavenWorkingSession newSession = session.execute(request);
         return newSession.regenerateSession();
     }
 


### PR DESCRIPTION
Hi, 

I'm using shrinkwrap resolver for a maven-based repo tool. It's fantastic, thanks for the great work!

Just one small fix. This pull request  adds missing interpolation in a Maven settings file if configured with "fromFile", e.g. a variable ${user.home} is expanded in a repo URL file://${user.home}/myrepo.

Example call:

```
 Maven.configureResolver()
            .fromFile(mavenSettingsFile)
            .addDependencies(dep)
            .resolve()
            .withMavenCentralRepo(useMavenCentral)
            .using(new AcceptScopesStrategy(scopeType))
            .asResolvedArtifact();
```

Cheers,

Jörg
