### PR TITLE
In some cases classpath resolution of artifacts yields an incorrect file.

### DIFF
--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/aether/ClasspathWorkspaceReader.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/aether/ClasspathWorkspaceReader.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -37,6 +36,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.apache.commons.io.FilenameUtils;
 import org.jboss.shrinkwrap.resolver.impl.maven.util.Validate;
 import org.sonatype.aether.artifact.Artifact;
 import org.sonatype.aether.repository.WorkspaceReader;
@@ -185,7 +185,7 @@ public class ClasspathWorkspaceReader implements WorkspaceReader {
 
                 // TODO: This is nasty
                 // we need to get a a pom.xml file to be sure we fetch transitive deps as well
-                if (file.getAbsolutePath().contains(name.toString())) {
+                if (FilenameUtils.removeExtension(file.getName()).equals(name.toString())) {
                     if ("pom".equals(artifact.getExtension())) {
                         // try to get pom file for the project
                         final FileInfo pomFileInfo = getPomFileInfo(file);


### PR DESCRIPTION
I found a specific case where some artifacts where being incorrectly resolved, resulting in the archive missing some dependencies.

These artifacts brought up the problem for us:
de.novanic.gwteventservice:gwteventservice:1.2.1
de.novanic.gwteventservice:eventservice:1.2.1

Because the name of the second artifact is a substring of the first artifact's file path, that second dependency is being resolved to the first one's file. This change set basically uses a stricter way of comparing the file's path against the artifact name to avoid these scenarios.

One workaround is to specify the dependencies in a particular order (we are using this at the moment), but finding the cause of the problem is not trivial.
