### PR TITLE
SHRINKRES-218: Have the test output directory available through ParsedPomFile

### DIFF
--- a/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/pom/ParsedPomFile.java
+++ b/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/pom/ParsedPomFile.java
@@ -120,6 +120,13 @@ public interface ParsedPomFile {
     File getTestSourceDirectory();
 
     /**
+     * Returns a directory where project test output is stored. Might be {@code null}.
+     *
+     * @return
+     */
+    File getTestOutputDirectory();
+
+    /**
      * Returns
      *
      * @return

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/pom/ParsedPomFileImpl.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/pom/ParsedPomFileImpl.java
@@ -200,6 +200,9 @@ public class ParsedPomFileImpl implements ParsedPomFile {
     }
 
     @Override
+    public File getTestOutputDirectory() { return new File(model.getBuild().getTestOutputDirectory()); }
+
+    @Override
     public Set<MavenDependency> getDependencyManagement() {
 
         // get dependency management


### PR DESCRIPTION
SHRINKRES-218: Have the test output directory available through org.jboss.shrinkwrap.resolver.api.maven.pom.ParsedPomFile