### PR TITLE
[SHRINKRES-220] updated versions of aether, maven and some plexus libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ branches:
         - /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
 before_install:
     # until SHRINKRES-203 is fixed, we need to build on older Maven
-    - wget http://www.us.apache.org/dist/maven/maven-3/3.1.1/binaries/apache-maven-3.1.1-bin.tar.gz
-    - tar xf apache-maven-3.1.1-bin.tar.gz
-    - export M2_HOME=$PWD/apache-maven-3.1.1
+    - wget http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
+    - tar xf apache-maven-3.2.5-bin.tar.gz
+    - export M2_HOME=$PWD/apache-maven-3.2.5
     - export PATH=$M2_HOME/bin/:$PATH
     - export MAVEN_SKIP_RC=true
     - mvn --version

--- a/impl-maven-archive/pom.xml
+++ b/impl-maven-archive/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.eclipse.sisu</groupId>
             <artifactId>org.eclipse.sisu.plexus</artifactId>
-            <version>0.0.0.M5</version>
+            <version>0.3.0.M1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>

--- a/impl-maven/pom.xml
+++ b/impl-maven/pom.xml
@@ -61,7 +61,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-wagon</artifactId>
+            <artifactId>aether-connector-basic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-transport-wagon</artifactId>
+            <version>${version.org.eclipse.aether}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.maven.wagon</groupId>
@@ -70,7 +75,7 @@
             </exclusions>
         </dependency>
        
-        <!-- org.apache.maven -->   
+        <!-- org.apache.maven -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-aether-provider</artifactId>
@@ -132,6 +137,13 @@
             <artifactId>maven-settings-builder</artifactId>
             <version>${version.org.apache.maven}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${version.com.google.guava}</version>
+        </dependency>
+        
 
         <!-- org.codehaus.plexus -->
         <dependency>

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/ManualWagonProvider.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/ManualWagonProvider.java
@@ -26,7 +26,7 @@ import org.apache.maven.wagon.providers.file.FileWagon;
 import org.apache.maven.wagon.providers.http.LightweightHttpWagon;
 import org.apache.maven.wagon.providers.http.LightweightHttpWagonAuthenticator;
 import org.apache.maven.wagon.providers.http.LightweightHttpsWagon;
-import org.eclipse.aether.connector.wagon.WagonProvider;
+import org.eclipse.aether.transport.wagon.WagonProvider;
 import org.jboss.shrinkwrap.resolver.api.ResolutionException;
 
 /**

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/ShrinkWrapResolverServiceLocator.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/ShrinkWrapResolverServiceLocator.java
@@ -34,8 +34,7 @@ import org.apache.maven.repository.internal.DefaultVersionResolver;
 import org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory;
 import org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory;
 import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.connector.wagon.WagonProvider;
-import org.eclipse.aether.connector.wagon.WagonRepositoryConnectorFactory;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.impl.ArtifactDescriptorReader;
 import org.eclipse.aether.impl.ArtifactResolver;
 import org.eclipse.aether.impl.DependencyCollector;
@@ -54,6 +53,7 @@ import org.eclipse.aether.impl.UpdatePolicyAnalyzer;
 import org.eclipse.aether.impl.VersionRangeResolver;
 import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.internal.impl.DefaultArtifactResolver;
+import org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider;
 import org.eclipse.aether.internal.impl.DefaultDependencyCollector;
 import org.eclipse.aether.internal.impl.DefaultDeployer;
 import org.eclipse.aether.internal.impl.DefaultFileProcessor;
@@ -64,18 +64,28 @@ import org.eclipse.aether.internal.impl.DefaultOfflineController;
 import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
 import org.eclipse.aether.internal.impl.DefaultRepositoryConnectorProvider;
 import org.eclipse.aether.internal.impl.DefaultRepositoryEventDispatcher;
+import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
 import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
 import org.eclipse.aether.internal.impl.DefaultSyncContextFactory;
+import org.eclipse.aether.internal.impl.DefaultTransporterProvider;
 import org.eclipse.aether.internal.impl.DefaultUpdateCheckManager;
 import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutFactory;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterProvider;
 import org.eclipse.aether.spi.io.FileProcessor;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.eclipse.aether.spi.locator.Service;
 import org.eclipse.aether.spi.locator.ServiceLocator;
 import org.eclipse.aether.spi.log.LoggerFactory;
+import org.eclipse.aether.transport.wagon.WagonProvider;
+import org.eclipse.aether.transport.wagon.WagonTransporterFactory;
 import org.jboss.shrinkwrap.resolver.impl.maven.logging.AetherLoggerFactory;
 
 /**
@@ -172,7 +182,14 @@ class ShrinkWrapResolverServiceLocator implements ServiceLocator {
         // add our own services
         setServices(ModelBuilder.class, new DefaultModelBuilderFactory().newInstance());
         setServices(WagonProvider.class, new ManualWagonProvider());
-        addService(RepositoryConnectorFactory.class, WagonRepositoryConnectorFactory.class);
+
+        // add default services introduced after aether 0.9.0.M2
+        addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
+        addService(TransporterProvider.class, DefaultTransporterProvider.class);
+        addService(TransporterFactory.class, WagonTransporterFactory.class);
+        addService(RepositoryLayoutProvider.class, DefaultRepositoryLayoutProvider.class);
+        addService(RepositoryLayoutFactory.class, Maven2RepositoryLayoutFactory.class);
+        addService(ChecksumPolicyProvider.class, DefaultChecksumPolicyProvider.class);
 
         // to avoid problems with SLF4J, we are having a JUL bridge
         setServices(LoggerFactory.class, new AetherLoggerFactory());

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -100,6 +100,12 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${version.org.apache.maven}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,17 +35,19 @@
         <maven.compiler.argument.source>1.5</maven.compiler.argument.source>
 
         <!-- Versioning -->
-        <version.org.apache.maven>3.1.1</version.org.apache.maven>
+        <version.org.apache.maven>3.2.5</version.org.apache.maven>
         <version.org.apache.maven.wagon>2.6</version.org.apache.maven.wagon>
+        
+        <version.com.google.guava>18.0</version.com.google.guava>
 
-        <version.org.codehaus.plexus.interpolation>1.19</version.org.codehaus.plexus.interpolation>
-        <version.org.codehaus.plexus.utils>3.0.15</version.org.codehaus.plexus.utils>
+        <version.org.codehaus.plexus.interpolation>1.21</version.org.codehaus.plexus.interpolation>
+        <version.org.codehaus.plexus.utils>3.0.20</version.org.codehaus.plexus.utils>
         <version.org.codehaus.plexus.classworlds>2.5.1</version.org.codehaus.plexus.classworlds>
         <version.org.codehaus.plexus.compiler.javac>2.3</version.org.codehaus.plexus.compiler.javac>
         <version.org.codehaus.plexus.sec.dispatcher>1.3</version.org.codehaus.plexus.sec.dispatcher>
 
         <!-- Aether version must be the same as used in Maven in order for plugin to work -->
-        <version.org.eclipse.aether>0.9.0.M2</version.org.eclipse.aether>
+        <version.org.eclipse.aether>1.0.0.v20140518</version.org.eclipse.aether>
 
         <version.gradle-tooling-api>2.1</version.gradle-tooling-api>
 


### PR DESCRIPTION
Updated versions of aether, maven and some plexus libs. 
Modified the implementation to suit the changes of dependencies. 
Added new aether-transport-wagon module introduced in aether-0.9.0.M3 and changed aether-connector-wagon module to aether-connector-basic
Added com.google.guava:guava dependency because it's functionality is used in new methods of the class:
 impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/internal/MavenModelResolver.java