### PR TITLE
add directory entries in generated jar from workspace for spring dependencies with annotations

### DIFF
--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenResolvedArtifactImpl.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenResolvedArtifactImpl.java
@@ -220,16 +220,14 @@ public class MavenResolvedArtifactImpl extends MavenArtifactInfoImpl implements 
         }
 
         private static void generateFileList(final List<String> list, final File root, final File file) {
-
-            String entryPath =
-                    file.getAbsolutePath().substring(root.getAbsolutePath().length() + 1).replace(File.separatorChar, '/');
-
             if (file.isFile()) {
                 // SHRINKRES-94 replacing all OS dependent separators with jar independent separator
-                list.add(entryPath);
+                list.add(file.getAbsolutePath().substring(
+                        root.getAbsolutePath().length() + 1).replace(File.separatorChar, '/'));
             } else if (file.isDirectory()) {
                 if (!file.equals(root)) {
-                    list.add(entryPath + File.separatorChar);
+                    list.add(file.getAbsolutePath().substring(
+                            root.getAbsolutePath().length() + 1).replace(File.separatorChar, '/') + File.separatorChar);
                 }
                 for (File next : file.listFiles()) {
                     generateFileList(list, root, next);


### PR DESCRIPTION
# Issue

In order to able to use spring annotations "component-scan" to bind classes the external jar files HAVE TO contains directory entries. If these entries are not present the automatic scan is not working.

In current version, the zip file build from a workspace project included in arquillian deployment does not contains this entries.

For more infos : http://stackoverflow.com/questions/1242656/spring-annotation-based-controllers-not-working-if-it-is-inside-jar-file

# Sample jar files content

## Sample jar content from maven

**Command :**
_unzip -l liferay-plugins-common-1.1.1.1-SNAPSHOT.jar_
**Output :**
Archive:  liferay-plugins-common-1.1.1.1-SNAPSHOT.jar
  Length     Date   Time    Name
 --------    ----   ----    ----
        0  06-16-15 12:37   com/sample/cloud/common/auth/
     3679  06-16-15 12:37   com/sample/cloud/common/auth/AccessTokenHelper.class
......
 --------                   -------
    90537                   74 files

**-> Contains folder entries** 

## Sample jar content from arquillian generator

**Command :** 
_unzip -l liferay-plugins-common-1.1.1.1-897907092644295391.jar_
**Output :**
Archive:  liferay-plugins-common-1.1.1.1-897907092644295391.jar
  Length     Date   Time    Name
 --------    ----   ----    ----
     3679  06-16-15 12:37   com/sample/cloud/common/auth/AccessTokenHelper.class
......
 --------                   -------
    90537                   42 files

**-> Contains no folder entries** 

# Fix

In the version from the pull request, folder are added in the zip files as zip entries.

Method used to add folder in the zip file : http://stackoverflow.com/questions/740375/directories-in-a-zip-file-when-using-java-util-zip-zipoutputstream
