### PR TITLE
Fix CL problem when used as java agent

### DIFF
--- a/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/coordinate/MavenDependencies.java
+++ b/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/coordinate/MavenDependencies.java
@@ -30,13 +30,25 @@ import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
  */
 public final class MavenDependencies {
 
-    private static final String NAME_IMPL_CLASS = "org.jboss.shrinkwrap.resolver.impl.maven.coordinate.MavenDependencyImpl";
+    private static final String NAME_IMPL_CLASS_NAME_KEY = "__shrinkwrap_maven_dependency_impl_class_name_key__";
+    private static final String DEFAULT_NAME_IMPL_CLASS = "org.jboss.shrinkwrap.resolver.impl.maven.coordinate.MavenDependencyImpl";
     private static final Constructor<MavenDependency> ctor;
     static {
         try {
+            ClassLoader classLoader = MavenDependencies.class.getClassLoader();
+
+            if (classLoader == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            }
+
+            String namedImplClassName = System.getProperty(NAME_IMPL_CLASS_NAME_KEY);
+
+            if(namedImplClassName == null || namedImplClassName.trim().length() == 0) {
+                namedImplClassName = DEFAULT_NAME_IMPL_CLASS;
+            }
+
             @SuppressWarnings("unchecked")
-            final Class<MavenDependency> clazz = (Class<MavenDependency>) MavenDependencies.class.getClassLoader()
-                .loadClass(NAME_IMPL_CLASS);
+            final Class<MavenDependency> clazz = (Class<MavenDependency>) classLoader.loadClass(namedImplClassName);
             ctor = clazz.getConstructor(MavenCoordinate.class, ScopeType.class, boolean.class,
                 MavenDependencyExclusion[].class);
         } catch (final Exception e) {

--- a/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/loader/SpiServiceLoader.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/loader/SpiServiceLoader.java
@@ -55,6 +55,11 @@ public class SpiServiceLoader implements ServiceLoader {
     public SpiServiceLoader() {
         // Use the CL which loaded this class as a default
         this.classLoader = SpiServiceLoader.class.getClassLoader();
+
+        // If the CL which loaded this class is null(When this class is loaded by bootstrap CL), use system CL instead.
+        if (classLoader == null) {
+            this.classLoader = ClassLoader.getSystemClassLoader();
+        }
     }
 
     /**


### PR DESCRIPTION
1. When package shrinkwrap resolver to a java agent, the class loader loaded shrinkwrap resolver's class is bootstrap class loader, and when use Class.getClassLoader() the get the class loader of a class that is loaded by bootstrap class loader, the result will be null, and will cause a NPE error. So when the class loader is null, use ClassLoader.getSystemClassLoader instead make sure that we will not use a null class loader to load class.
2. When shading shrinkwrap resolver to a java agent using maven's shade plugin, and modify the package of shrinkwrap resolver, for example, modify org.boss to com.myagent.org.jboss, the hard coded NAME_IMPL_CLASS will cause a ClassNotFoundException, so added a system properties to specify the NAME_IMPL_CLASS value.
