### PR TITLE
SHRINKRES-226 Loading of the settings.xml configuration has been postponed

### DIFF
--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/ConfigurableMavenWorkingSessionImpl.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/ConfigurableMavenWorkingSessionImpl.java
@@ -1,3 +1,19 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.shrinkwrap.resolver.impl.maven;
 
 import java.io.File;

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/ConfigurableMavenWorkingSessionImpl.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/ConfigurableMavenWorkingSessionImpl.java
@@ -1,0 +1,153 @@
+package org.jboss.shrinkwrap.resolver.impl.maven;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.maven.settings.Settings;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.jboss.shrinkwrap.resolver.api.InvalidConfigurationFileException;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenWorkingSession;
+import org.jboss.shrinkwrap.resolver.impl.maven.bootstrap.MavenRepositorySystem;
+
+/**
+ * Configurable implementation of a {@link MavenWorkingSession}, encapsulating Maven/Aether backend.
+ * <br/>
+ * This is an abstract class and doesn't contain all the implementation - this class contains:
+ * <ul>
+ * <li>methods for generating an instance of {@link DefaultRepositorySystemSession} when necessary</li>
+ * <li>methods for modification of properties related to the {@link DefaultRepositorySystemSession}</li>
+ * <li>methods related to the {@link MavenWorkingSession} that doesn't need to have created an instance
+ * of the {@link DefaultRepositorySystemSession} for its calling</li>
+ * <li>delegating methods related to {@link Settings}</li>
+ * </ul>
+ *
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ * @author <a href="mailto:kpiwko@redhat.com">Karel Piwko</a>
+ * @author <a href="mailto:mmatloka@gmail.com">Michal Matloka</a>
+ */
+public abstract class ConfigurableMavenWorkingSessionImpl implements MavenWorkingSession {
+
+    private static final Logger log = Logger.getLogger(ConfigurableMavenWorkingSessionImpl.class.getName());
+
+    private DefaultRepositorySystemSession session;
+    private SettingsManager settingsManager;
+    private boolean useLegacyLocalRepository = false;
+    private final MavenRepositorySystem system;
+    private boolean disableClassPathWorkspaceReader = false;
+
+    public ConfigurableMavenWorkingSessionImpl() {
+        this.system = new MavenRepositorySystem();
+        this.settingsManager = new SettingsManager();
+    }
+
+    @Override
+    public MavenWorkingSession configureSettingsFromFile(File globalSettings, File userSettings)
+        throws InvalidConfigurationFileException {
+        this.settingsManager.configureSettingsFromFile(globalSettings, userSettings);
+        return regenerateSession();
+    }
+
+    @Override
+    public MavenWorkingSession regenerateSession() {
+        generateSession();
+        return this;
+    }
+
+    @Override
+    public void setOffline(final boolean offline) {
+        if (log.isLoggable(Level.FINER)) {
+            log.finer("Set offline mode programatically to: " + offline);
+        }
+        this.settingsManager.setOffline(offline);
+
+        // TODO: this won't be necessary when the deprecated API is removed
+        regenerateSessionIfNotNull();
+    }
+
+    @Override
+    public void disableClassPathWorkspaceReader() {
+        if (log.isLoggable(Level.FINEST)) {
+            log.finest("Disabling ClassPath resolution");
+        }
+        disableClassPathWorkspaceReader = true;
+
+        // TODO: this won't be necessary when the deprecated API is removed
+        regenerateSessionIfNotNull();
+    }
+
+    @Override
+    public void useLegacyLocalRepository(boolean useLegacyLocalRepository) {
+        if (this.useLegacyLocalRepository == useLegacyLocalRepository) {
+            return;
+        }
+
+        log.log(Level.FINEST, "Using legacy local repository");
+        this.useLegacyLocalRepository = useLegacyLocalRepository;
+
+        // TODO: this won't be necessary when the deprecated API is removed
+        regenerateSessionIfNotNull();
+    }
+
+    /**
+     * Returns an instance of the {@link DefaultRepositorySystemSession} that is generated if hasn't been yet.
+     *
+     * @return an instance of the {@link DefaultRepositorySystemSession}
+     */
+    protected DefaultRepositorySystemSession getSession() {
+        if (this.session == null) {
+            generateSession();
+        }
+        return this.session;
+    }
+
+    /**
+     * Returns an instance of the {@link Settings}.
+     *
+     * @return an instance of the {@link Settings}
+     * @see SettingsManager#getSettings()
+     */
+    protected Settings getSettings() {
+        return this.settingsManager.getSettings();
+    }
+
+    /**
+     * Returns whether the resolver should work in offline mode or not
+     *
+     * @return whether the resolver should work in offline mode or not
+     * @see SettingsManager#isOffline()
+     */
+    protected boolean isOffline() {
+        return this.settingsManager.isOffline();
+    }
+
+    /**
+     * Returns an instance of the {@link MavenRepositorySystem}.
+     *
+     * @return an instance of the {@link MavenRepositorySystem}
+     */
+    protected MavenRepositorySystem getSystem() {
+        return this.system;
+    }
+
+    // utility methods
+
+    /**
+     * Regenerates an instance of the {@link DefaultRepositorySystemSession} if there is already any
+     */
+    private void regenerateSessionIfNotNull() {
+        if (this.session != null) {
+            regenerateSession();
+        }
+    }
+
+    /**
+     * Generates an instance of the {@link DefaultRepositorySystemSession} and takes into account related properties
+     */
+    private void generateSession() {
+        this.session = this.system.getSession(getSettings(), this.useLegacyLocalRepository);
+        if (this.disableClassPathWorkspaceReader) {
+            ((DefaultRepositorySystemSession) this.session).setWorkspaceReader(null);
+        }
+    }
+}

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/SettingsManager.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/SettingsManager.java
@@ -1,0 +1,97 @@
+package org.jboss.shrinkwrap.resolver.impl.maven;
+
+import java.io.File;
+
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuildingRequest;
+import org.jboss.shrinkwrap.resolver.api.InvalidConfigurationFileException;
+import org.jboss.shrinkwrap.resolver.impl.maven.bootstrap.MavenSettingsBuilder;
+
+/**
+ * A manager for {@link Settings} and related options and operations,
+ * it handles building of an instance of {@link Settings} when necessary and regenerating after changes.
+ *
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ * @author <a href="mailto:kpiwko@redhat.com">Karel Piwko</a>
+ * @author <a href="mailto:mmatloka@gmail.com">Michal Matloka</a>
+ */
+public class SettingsManager {
+
+    private Settings settings;
+
+    // make sure that programmatic call to offline method is always preserved
+    private Boolean programmaticOffline;
+
+    /**
+     * Crates an instance of {@link Settings} and configures it from the given file.
+     *
+     * @param globalSettings path to global settings file
+     * @param userSettings   path to user settings file
+     * @throws InvalidConfigurationFileException
+     */
+    public void configureSettingsFromFile(File globalSettings, File userSettings)
+        throws InvalidConfigurationFileException {
+
+        SettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
+        if (globalSettings != null) {
+            request.setGlobalSettingsFile(globalSettings);
+        }
+        if (userSettings != null) {
+            request.setUserSettingsFile(userSettings);
+        }
+        request.setSystemProperties(SecurityActions.getProperties());
+
+        MavenSettingsBuilder builder = new MavenSettingsBuilder();
+        this.settings = builder.buildSettings(request);
+
+        // ensure we keep offline(boolean) if previously set
+        propagateProgrammaticOfflineIntoSettings();
+    }
+
+    /**
+     * Returns an instance of the {@link Settings}, if it hasn't been created yet, it generates it from the default settings.
+     *
+     * @return an instance of the {@link Settings}
+     */
+    protected Settings getSettings() {
+        if (this.settings == null) {
+            this.settings = new MavenSettingsBuilder().buildDefaultSettings();
+            // ensure we keep offline(boolean) if previously set
+            propagateProgrammaticOfflineIntoSettings();
+        }
+        return this.settings;
+    }
+
+    /**
+     * Sets programaticOffline to the given value - whether the resolver should work in offline mode or not,
+     * in case that an instance of the {@link Settings} has been created, the value is propagated into it
+     *
+     * @param programmaticOffline whether the resolver should work in offline mode or not
+     */
+    protected void setOffline(Boolean programmaticOffline) {
+        this.programmaticOffline = new Boolean(programmaticOffline);
+        // propagate offline(boolean) into settings if previously created
+        propagateProgrammaticOfflineIntoSettings();
+    }
+
+    /**
+     * Returns whether the resolver should work in offline mode or not,
+     * If the programmaticOffline hasn't been set yet, the value is taken from a {@link Settings} instance
+     *
+     * @return whether the resolver should work in offline mode or not
+     */
+    protected boolean isOffline() {
+        if (this.programmaticOffline != null) {
+            return this.programmaticOffline.booleanValue();
+        }
+        return this.getSettings().isOffline();
+    }
+
+    // utility methods
+    private void propagateProgrammaticOfflineIntoSettings() {
+        if (this.programmaticOffline != null && this.settings != null) {
+            this.settings.setOffline(this.programmaticOffline.booleanValue());
+        }
+    }
+}

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/SettingsManager.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/SettingsManager.java
@@ -1,3 +1,19 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.shrinkwrap.resolver.impl.maven;
 
 import java.io.File;

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/task/ConfigureSettingsFromFileTask.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/task/ConfigureSettingsFromFileTask.java
@@ -70,8 +70,7 @@ public class ConfigureSettingsFromFileTask implements MavenWorkingSessionTask<Ma
             throw new InvalidConfigurationFileException(e.getMessage());
         }
 
-        final MavenWorkingSession newSession = session.configureSettingsFromFile(null, settingsXmlFile);
-        return newSession.regenerateSession();
+        return session.configureSettingsFromFile(null, settingsXmlFile);
     }
 
 }

--- a/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/InvalidSettingsTestCase.java
+++ b/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/InvalidSettingsTestCase.java
@@ -1,0 +1,191 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.integration;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.resolver.api.InvalidConfigurationFileException;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolverSystem;
+import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependency;
+import org.jboss.shrinkwrap.resolver.api.maven.repository.MavenChecksumPolicy;
+import org.jboss.shrinkwrap.resolver.api.maven.repository.MavenRemoteRepositories;
+import org.jboss.shrinkwrap.resolver.impl.maven.bootstrap.MavenSettingsBuilder;
+import org.jboss.shrinkwrap.resolver.impl.maven.util.TestFileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test Case for SHRINKRES-226 - Loading of the settings.xml configuration has been postponed. This test case aims at
+ * (no-)loading of the invalid settings.xml, not at the result of resolving etc...
+ *
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+public class InvalidSettingsTestCase {
+
+    private static final String INVALID_SETTINGS = "target/settings/profiles/settings-invalid.xml";
+    private static final String CENTRAL_SETTINGS = "target/settings/profiles/settings-central.xml";
+    private static final String FROM_CLASSLOADER = "profiles/settings3-from-classpath.xml";
+    private static final String JUNIT_CANONICAL = "junit:junit:4.11";
+    private static final File TEST_BOM = new File("target/poms/test-bom.xml");
+
+    @BeforeClass
+    public static void setRemoteRepository() {
+        System.setProperty(MavenSettingsBuilder.ALT_GLOBAL_SETTINGS_XML_LOCATION, INVALID_SETTINGS);
+        System.setProperty(MavenSettingsBuilder.ALT_USER_SETTINGS_XML_LOCATION, INVALID_SETTINGS);
+    }
+
+    private final MavenDependency dependency = MavenDependencies.createDependency(
+        "org.jboss.shrinkwrap.test:test-dependency-test:1.0.0", ScopeType.TEST, false);
+
+    /**
+     * Cleanup, remove the repositories from previous tests
+     */
+    @Before
+    @After
+    // For debugging you might want to temporarily remove the @After lifecycle call just to sanity-check for yourself
+    // the repo
+    public void cleanup() throws Exception {
+        TestFileUtil.removeDirectory(new File("target/local-only-repository"));
+    }
+
+    /**
+     * Testing methods, that doesn't need to have loaded configuration for its calling
+     * During this test the settings-invalid.xml shouldn't be loaded so no exception should be thrown
+     * <br/>
+     * Uses method Maven.configureResolver()
+     */
+    @Test
+    public void shouldNotLoadInvalidSettingsCR() {
+        Maven.configureResolver().withRemoteRepo(MavenRemoteRepositories.createRemoteRepository("jboss",
+            "https://repository.jboss.org/nexus/content/repositories/releases/", "default")
+            .setChecksumPolicy(MavenChecksumPolicy.CHECKSUM_POLICY_IGNORE));
+
+        Maven.configureResolver().workOffline();
+        Maven.configureResolver().workOffline(true);
+        Maven.configureResolver().useLegacyLocalRepo(true);
+        Maven.configureResolver().withClassPathResolution(false);
+        Maven.configureResolver().withMavenCentralRepo(false);
+        Maven.configureResolver().addDependency(dependency);
+    }
+
+    /**
+     * Testing methods, that doesn't need to have loaded configuration for its calling
+     * During this test the settings-invalid.xml shouldn't be loaded so no exception should be thrown
+     * <br/>
+     * Uses method Maven.resolver()
+     */
+    @Test
+    public void shouldNotLoadInvalidSettingsR() {
+        Maven.resolver().offline();
+        Maven.resolver().offline(true);
+        Maven.resolver().addDependency(dependency);
+    }
+
+    /**
+     * In this test the settings-invalid.xml should be loaded during the
+     * <code>resolve("junit:junit:4.11").withTransitivity()</code> phase,
+     * for this reason the InvalidConfigurationFileException should be thrown
+     * <br/>
+     * Uses method Maven.configureResolver()
+     */
+    @Test(expected = InvalidConfigurationFileException.class)
+    public void shouldLoadInvalidSettingsDueResolvingCR() {
+        Maven.configureResolver().resolve(JUNIT_CANONICAL).withTransitivity();
+    }
+
+    /**
+     * In this test the settings-invalid.xml should be loaded during the
+     * <code>resolve("junit:junit:4.11").withTransitivity()</code> phase,
+     * for this reason the InvalidConfigurationFileException should be thrown
+     * <br/>
+     * Uses method Maven.resolver()
+     */
+    @Test(expected = InvalidConfigurationFileException.class)
+    public void shouldLoadInvalidSettingsDueResolvingR() {
+        Maven.resolver().resolve(JUNIT_CANONICAL).withTransitivity();
+    }
+
+    /**
+     * In this test the settings-invalid.xml should be loaded during the
+     * <code>resolveVersionRange("junit:junit")</code> phase,
+     * for this reason the InvalidConfigurationFileException should be thrown
+     * <br/>
+     * Uses method Maven.configureResolver()
+     */
+    @Test(expected = InvalidConfigurationFileException.class)
+    public void shouldLoadInvalidSettingsDueResolvingVersionsCR() {
+        Maven.configureResolver().resolveVersionRange(JUNIT_CANONICAL);
+    }
+
+    /**
+     * In this test the settings-invalid.xml should be loaded during the
+     * <code>resolveVersionRange("junit:junit")</code> phase,
+     * for this reason the InvalidConfigurationFileException should be thrown
+     * <br/>
+     * Uses method Maven.resolver()
+     */
+    @Test(expected = InvalidConfigurationFileException.class)
+    public void shouldLoadInvalidSettingsDueResolvingVersionsR() {
+        Maven.resolver().resolveVersionRange(JUNIT_CANONICAL);
+    }
+
+    /**
+     * In this test the settings-invalid.xml should be loaded during the
+     * <code>loadPomFromFile(new File("target/poms/test-bom.xml"))</code> phase,
+     * for this reason the InvalidConfigurationFileException should be thrown
+     * <br/>
+     * Uses method Maven.configureResolver()
+     */
+    @Test(expected = InvalidConfigurationFileException.class)
+    public void shouldLoadInvalidSettingsDueLoadingPomCR() {
+        Maven.configureResolver().loadPomFromFile(TEST_BOM);
+    }
+
+    /**
+     * In this test the settings-invalid.xml should be loaded during the
+     * <code>loadPomFromFile(new File("target/poms/test-bom.xml")</code> phase,
+     * for this reason the InvalidConfigurationFileException should be thrown
+     * <br/>
+     * Uses method Maven.resolver()
+     */
+    @Test(expected = InvalidConfigurationFileException.class)
+    public void shouldLoadInvalidSettingsDueLoadingPomR() {
+        Maven.resolver().loadPomFromFile(TEST_BOM);
+    }
+
+    /**
+     * During this test the settings-invalid.xml should NOT be loaded, but the settings-central.xml should.
+     * No exception should be thrown.
+     * <br/>
+     * Uses method Maven.configureResolver()
+     */
+    @Test
+    public void shouldLoadCentralSettingsFromFileCR() {
+        // from file
+        MavenResolverSystem centralFromFile = Maven.configureResolver().fromFile(CENTRAL_SETTINGS);
+        shouldResolveAndLoadPom(centralFromFile);
+
+        // configure from file
+        MavenResolverSystem centralConfigureFromFile = Maven.configureResolver().configureFromFile(CENTRAL_SETTINGS);
+        shouldResolveAndLoadPom(centralConfigureFromFile);
+
+        //from classloader resource
+        MavenResolverSystem fromClassloaderRes =
+            Maven.configureResolver().fromClassloaderResource(FROM_CLASSLOADER);
+        shouldResolveAndLoadPom(fromClassloaderRes);
+
+        // configure from classloader resource
+        MavenResolverSystem configFromClassloaderRes =
+            Maven.configureResolver().configureFromClassloaderResource(FROM_CLASSLOADER);
+        shouldResolveAndLoadPom(configFromClassloaderRes);
+    }
+
+    private void shouldResolveAndLoadPom(MavenResolverSystem mavenResolverSystem) {
+        mavenResolverSystem.resolve(JUNIT_CANONICAL).withTransitivity();
+        mavenResolverSystem.loadPomFromFile(TEST_BOM);
+    }
+
+}

--- a/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/InvalidSettingsTestCase.java
+++ b/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/InvalidSettingsTestCase.java
@@ -1,3 +1,19 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.shrinkwrap.resolver.impl.maven.integration;
 
 import java.io.File;

--- a/impl-maven/src/test/resources/profiles/settings-invalid.xml
+++ b/impl-maven/src/test/resources/profiles/settings-invalid.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+   invalid element of local repository</localRepository>
+
+   <profiles>
+      <profile>
+         <activation>
+            <activeByDefault>true</activeByDefault>
+         </activation>
+        this is invalid settings!!!
+      </profile>
+   </profiles>
+</settings>


### PR DESCRIPTION
Previously, when the Maven.configureResolver() was called, the default settings.xml was immediately loaded - this is not always appropriate - see: https://developer.jboss.org/message/936418

I've created two new classes:
SettingsManager.java
- is a manager for all operation related to an instance of the Settings
- handles the (re)generation of the Settings and keeps the instance

ConfigurableMavenWorkingSessionImpl.java
- handles all operation related to DefaultRepositorySystemSession that doesn't need to have created an instance of the DefaultRepositorySystemSession for its calling
- handles the (re)generation of the DefaultRepositorySystemSession and  keeps the instance
- this kind of methods have been moved from MavenWorkingSessionImpl class

I've attached also the test case