### PR TITLE
SHRINKRES-231 Modified regex to match correct ciphers, added test case

### DIFF
--- a/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/MavenPlexusCipherTestCase.java
+++ b/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/MavenPlexusCipherTestCase.java
@@ -1,0 +1,149 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jboss.shrinkwrap.resolver.impl.maven.integration;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.shrinkwrap.resolver.impl.maven.internal.decrypt.MavenPlexusCipher;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.sonatype.plexus.components.cipher.PlexusCipherException;
+
+/**
+ * Tests the {@link MavenPlexusCipher} whether it correctly evaluates and undecorates the right strings containing a cipher.
+ *
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+@RunWith(Parameterized.class)
+public class MavenPlexusCipherTestCase {
+
+    private static final String UNDECORATED_CIPHER = "70+YZM/w7f8HQrEZUGZABCHAW62qMo+Y8okw7xzLwOM=";
+
+    private static final String ONLY_CIPHER = "{" + UNDECORATED_CIPHER + "}";
+
+    // Possible strings that could be before/after the cipher
+    private static final String[] DECORATION_VARIANTS =
+        {
+            "",
+            "    ",
+            "\n",
+            "    \n  \n",
+            "  blah  \n blah \n",
+            "    \n  ${variable} \n",
+            "\t",
+            //            "{",
+            "}"
+        };
+
+    // Possible strings that doesn't contain a valid cipher, but could be confusing
+    private static final String[] WITHOUT_CIPHER_VARIANTS =
+        {
+            "\\" + ONLY_CIPHER,
+            "$" + ONLY_CIPHER,
+            "\\\\" + ONLY_CIPHER + "",
+            "{" + UNDECORATED_CIPHER,
+            "{" + UNDECORATED_CIPHER + "\\}",
+            "{" + UNDECORATED_CIPHER + "\\\\}",
+            UNDECORATED_CIPHER + "}",
+            UNDECORATED_CIPHER
+        };
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> getParameters() {
+
+        List<Object[]> parameters = new ArrayList<Object[]>();
+        for (String decorator1 : DECORATION_VARIANTS) {
+            for (String decorator2 : DECORATION_VARIANTS) {
+                String decCombination = decorator1 + decorator2;
+
+                addCombinations(decorator1, decorator2, decCombination, ONLY_CIPHER, parameters, true);
+                for (String withoutString : WITHOUT_CIPHER_VARIANTS) {
+
+                    if ((withoutString.endsWith("\\}") || withoutString.endsWith(UNDECORATED_CIPHER))
+                        && (decorator1.contains("}") || decorator2.contains("}"))) {
+                        continue;
+                    }
+                    addCombinations(decorator1, decorator2, decCombination, withoutString, parameters, false);
+                }
+            }
+        }
+        return parameters;
+    }
+
+    private static void addCombinations(String decorator1, String decorator2, String decCombination,
+        String cipherString, List<Object[]> parameters, boolean isPresent) {
+
+        parameters.add(new Object[] { decCombination + cipherString, new Boolean(isPresent) });
+        parameters.add(new Object[] { cipherString + decCombination, new Boolean(isPresent) });
+        parameters.add(new Object[] { decCombination + cipherString + decCombination, new Boolean(isPresent) });
+        parameters.add(new Object[] { decorator1 + cipherString + decorator2, new Boolean(isPresent) });
+        parameters.add(new Object[] { decorator2 + cipherString + decorator1, new Boolean(isPresent) });
+    }
+
+    private String str;
+    private boolean isStringEcrypted;
+
+    public MavenPlexusCipherTestCase(String str, Boolean isCypherPresent) {
+        this.str = str;
+        this.isStringEcrypted = isCypherPresent;
+    }
+
+    /**
+     * Checks if the method {@link MavenPlexusCipher#isEncryptedString(String)} correctly evaluates whether the given
+     * string represents a cipher or not.
+     */
+    @Test
+    public void testIsEncryptedString() {
+        MavenPlexusCipher mavenPlexusCipher = new MavenPlexusCipher();
+        Assert.assertEquals(
+            "The evaluation of the string " + str + " whether it represents a cipher has failed",
+            isStringEcrypted, mavenPlexusCipher.isEncryptedString(str));
+    }
+
+    /**
+     * Checks if the method {@link MavenPlexusCipher#unDecorate(String)} correctly undecorates the given string
+     * and returns the right cipher.
+     */
+    @Test
+    public void testUnDecorate() throws PlexusCipherException {
+        MavenPlexusCipher mavenPlexusCipher = new MavenPlexusCipher();
+        try {
+            String undecorated = mavenPlexusCipher.unDecorate(str);
+
+            if (isStringEcrypted) {
+                Assert.assertEquals("The comparison of the udecorated string and expected cipher has failed",
+                    UNDECORATED_CIPHER, undecorated);
+
+            } else {
+                Assert.fail("The IllegalStateException should have been thrown here - the string: " + str
+                    + " doesn't represent an encrypted string. The method \"unDecorate\" returned: " + undecorated);
+            }
+
+        } catch (IllegalStateException ise) {
+            if (isStringEcrypted) {
+                Assert.fail("The evaluation or undecoration of the string: " + str
+                    + " has failed, although it should have passed - it represents an encrypted string");
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
see: 
[SHRINKRES-231 - MavenPlexusCipher matches string that doesn't represent a cipher](https://issues.jboss.org/browse/SHRINKRES-231)
[SHRINKRES-227 - ShrinkWrap Maven Resolver doesn't support env vars in settings.xml](https://issues.jboss.org/browse/SHRINKRES-227)
I've created two phased verification:
1.phase matches a cipher within {} that has some preceding string except:
    ${bla}
    \{bla}
2. phase matches a cipher within {} without having any preceding string (starting on the beginning of line)