### PR TITLE
SHRINKRES-233 Look at additional MAVEN_HOME env variable.

### DIFF
--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenSettingsBuilder.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenSettingsBuilder.java
@@ -93,8 +93,9 @@ public class MavenSettingsBuilder {
         String userHome = SecurityActions.getProperty("user.home");
         // it might happen that "M2_HOME" is not defined
         String m2HomeEnv = SecurityActions.getEnvProperty("M2_HOME");
+        String mHomeEnv = SecurityActions.getEnvProperty("MAVEN_HOME");
         String m2HomeProp = SecurityActions.getProperty("maven.home");
-        String m2Home = m2HomeEnv == null ? m2HomeProp : m2HomeEnv;
+        String m2Home = getFirstNotNull(m2HomeProp, m2HomeEnv, mHomeEnv);
 
         // note that pointing settings.xml to a non existining file does not matter here
         DEFAULT_GLOBAL_SETTINGS_PATH = m2Home == null ? "conf/settings.xml" : m2Home.concat("/conf/settings.xml".replace(
@@ -106,6 +107,15 @@ public class MavenSettingsBuilder {
         DEFAULT_SETTINGS_SECURITY_PATH = userHome == null ? ".settings-security.xml" : userHome
                 .concat("/.m2/settings-security.xml").replace('/', File.separatorChar);
 
+    }
+
+    static String getFirstNotNull(String... values) {
+        for(String value : values) {
+            if(value != null) {
+                return value;
+            }
+        }
+        return null;
     }
 
     /**

--- a/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenSettingsBuilderUnitTestCase.java
+++ b/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenSettingsBuilderUnitTestCase.java
@@ -103,4 +103,10 @@ public class MavenSettingsBuilderUnitTestCase {
         Assert.assertEquals("Password was decrypted to shrinkwrap", "shrinkwrap", server.getPassword());
     }
 
+    @Test
+    public void shouldRetrieveFirstNonNullString() {
+        String value = MavenSettingsBuilder.getFirstNotNull(null, "shrinkwrap");
+        Assert.assertEquals("shrinkwrap", value);
+    }
+
 }


### PR DESCRIPTION
This adds support for the env variable MAVEN_HOME ootb.  Some of us who have been using maven for really long times still use this variable, and it does point to a valid M2/M3 installation.

Note that locally I received two test failures on master prior to starting this work,  They still failed after I made my changes
```
houldOverloadRepository(org.jboss.shrinkwrap.resolver.impl.maven.integration.AdditionalRemoteRepositoryTestCase)  Time elapsed: 0.568 sec  <<< FAILURE!
java.lang.AssertionError: Expected exception: org.jboss.shrinkwrap.resolver.api.NoResolvedResultException
	at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:32)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)

shouldOverloadCentral(org.jboss.shrinkwrap.resolver.impl.maven.integration.AdditionalRemoteRepositoryTestCase)  Time elapsed: 1.037 sec  <<< FAILURE!
java.lang.AssertionError: Expected exception: org.jboss.shrinkwrap.resolver.api.NoResolvedResultException
	at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:32)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```