### PR TITLE
SHRINKRES-256 Added Maven BOM into SWR shrinkwrap-resolver-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -118,6 +118,15 @@
         <artifactId>shrinkwrap-resolver-impl-gradle-embedded-archive</artifactId>
         <version>${project.version}</version>
       </dependency>
+
+       <!-- Maven BOM -->
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven</artifactId>
+        <version>3.3.9</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
     </dependencies>
   
   </dependencyManagement>


### PR DESCRIPTION
To avoid cases, that user has different version of aether (and other libraries) on his classpath.