### PR TITLE
Fix jfrog's gradle repo URL

### DIFF
--- a/gradle/impl-gradle-embedded-archive/pom.xml
+++ b/gradle/impl-gradle-embedded-archive/pom.xml
@@ -75,7 +75,7 @@
         <repository>
             <id>jfrog</id>
             <name>jfrog</name>
-            <url>http://repo.jfrog.org/artifactory/repo</url>
+            <url>https://repo.jfrog.org/artifactory/gradle</url>
         </repository>
     </repositories>
 </project>

--- a/gradle/impl-gradle/pom.xml
+++ b/gradle/impl-gradle/pom.xml
@@ -69,7 +69,7 @@
         <repository>
             <id>jfrog</id>
             <name>jfrog</name>
-            <url>http://repo.jfrog.org/artifactory/repo</url>
+            <url>https://repo.jfrog.org/artifactory/gradle</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
http://repo.jfrog.org/artifactory/repo no longer works

Not sure if it's temporary hick up, but does not seem so.