### PR TITLE
Fix convenience methods to import dependencies

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -357,7 +357,7 @@ Maven.resolver().loadPomFromClassLoaderResource("/path/to/pom.xml").resolve("G:A
 ----
 
 Resolving artifacts defined in effective POM::
-ShrinkWrap Resolvers allows you to artifacts defined with specific scope into list of artifacts to be resolved. This way, you don't need to alter your tests if you change dependencies of your application. You can either use +importDependencies(ScopeType...)+ or convenience methods, that cover the most frequent usages (+importRuntimeDependencies()+, +importTestDependencies()+ and +importRuntimeAndTestDependencies()+:
+ShrinkWrap Resolvers allows you to import artifacts from your POM file, select them by specific scopes and resolve them. This way, you don't need to resolve every single dependency separately or alter your tests if you change dependencies of your application. You can either use +importDependencies(ScopeType...)+ or convenience methods, that cover the most frequent usages (+importCompileAndRuntimeDependencies()+, +importRuntimeDependencies()+, +importTestDependencies()+ and +importRuntimeAndTestDependencies()+):
 +
 [source,java]
 ----

--- a/maven/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/PomEquippedResolveStageBase.java
+++ b/maven/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/PomEquippedResolveStageBase.java
@@ -44,22 +44,23 @@ public interface PomEquippedResolveStageBase<RESOLVESTAGETYPE extends MavenResol
     RESOLVESTAGETYPE importTestDependencies();
 
     /**
-     * Adds all dependencies defined in imported POM file included in test, compile(default), system, and import scopes for resolution
+     * Adds all dependencies defined in imported POM file included in runtime, test, system, and import scopes for
+     * resolution
      *
      * @return Modified instance to allow chaining
      */
     RESOLVESTAGETYPE importRuntimeAndTestDependencies();
 
     /**
-     * Adds all dependencies defined in imported POM file included in compile(default), system, import and runtime scopes for
-     * resolution
+     * Adds all dependencies defined in imported POM file included in runtime, system, import scopes for resolution
      *
      * @return Modified instance to allow chaining
      */
     RESOLVESTAGETYPE importRuntimeDependencies();
 
     /**
-     * More explicit alias equivalent to {@link org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStageBase#importRuntimeDependencies()}
+     * Adds all dependencies defined in imported POM file included in compile, runtime, system, and import scopes for
+     * resolution
      *
      * @return Modified instance to allow chaining
      */

--- a/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/PomEquippedResolveStageBaseImpl.java
+++ b/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/PomEquippedResolveStageBaseImpl.java
@@ -56,17 +56,17 @@ public abstract class PomEquippedResolveStageBaseImpl<EQUIPPEDRESOLVESTAGETYPE e
 
     @Override
     public EQUIPPEDRESOLVESTAGETYPE importRuntimeAndTestDependencies() {
-        return importAnyDependencies(ScopeType.COMPILE, ScopeType.IMPORT, ScopeType.SYSTEM, ScopeType.RUNTIME, ScopeType.TEST);
+        return importAnyDependencies(ScopeType.RUNTIME, ScopeType.TEST, ScopeType.IMPORT, ScopeType.SYSTEM);
     }
 
     @Override
     public EQUIPPEDRESOLVESTAGETYPE importRuntimeDependencies() {
-        return importAnyDependencies(ScopeType.COMPILE, ScopeType.IMPORT, ScopeType.SYSTEM, ScopeType.RUNTIME);
+        return importAnyDependencies(ScopeType.RUNTIME, ScopeType.IMPORT, ScopeType.SYSTEM);
     }
 
     @Override
     public EQUIPPEDRESOLVESTAGETYPE importCompileAndRuntimeDependencies() {
-        return this.importRuntimeDependencies();
+        return importAnyDependencies(ScopeType.COMPILE, ScopeType.RUNTIME, ScopeType.IMPORT, ScopeType.SYSTEM);
     }
 
     @SuppressWarnings("unchecked")

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/ArtifactDependenciesTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/ArtifactDependenciesTestCase.java
@@ -61,7 +61,9 @@ public class ArtifactDependenciesTestCase {
     public void pomBasedArtifactLocatedInClassPath() {
 
         File[] files = Maven.configureResolver().fromClassloaderResource("profiles/settings3.xml")
-            .loadPomFromClassLoaderResource("poms/test-parent.xml").importRuntimeDependencies().resolve().withTransitivity().as(File.class);
+            .loadPomFromClassLoaderResource("poms/test-parent.xml")
+            .importCompileAndRuntimeDependencies()
+            .resolve().withTransitivity().as(File.class);
 
         ValidationUtil.fromDependencyTree(new File("src/test/resources/dependency-trees/test-parent.tree"),
             ScopeType.COMPILE, ScopeType.RUNTIME).validate(files);
@@ -73,7 +75,8 @@ public class ArtifactDependenciesTestCase {
     public void pomBasedArtifactLocatedInsideJar() {
 
         File[] files = Maven.configureResolver().fromClassloaderResource("profiles/settings3-from-classpath.xml")
-            .loadPomFromClassLoaderResource("poms/test-parent-from-classpath.xml").importRuntimeDependencies()
+            .loadPomFromClassLoaderResource("poms/test-parent-from-classpath.xml")
+            .importCompileAndRuntimeDependencies()
             .resolve().withTransitivity().as(File.class);
 
         ValidationUtil.fromDependencyTree(new File("src/test/resources/dependency-trees/test-parent.tree"),

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/OfflineRepositoryTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/OfflineRepositoryTestCase.java
@@ -123,7 +123,8 @@ public class OfflineRepositoryTestCase {
             final String pomFile = "poms/test-parent.xml";
 
             // Precondition; we can resolve when connected
-            final File[] files = Maven.resolver().loadPomFromClassLoaderResource(pomFile).importRuntimeDependencies()
+            final File[] files = Maven.resolver().loadPomFromClassLoaderResource(pomFile)
+                    .importCompileAndRuntimeDependencies()
                     .resolve().withTransitivity().as(File.class);
             ValidationUtil.fromDependencyTree(new File("src/test/resources/dependency-trees/test-parent.tree"),
                     ScopeType.COMPILE, ScopeType.RUNTIME).validate(files);
@@ -134,8 +135,9 @@ public class OfflineRepositoryTestCase {
             // Now try in offline mode and ensure we cannot resolve because we cannot hit repository defined in pom.xml (working
             // offline) and local repository was cleaned
             exception.expect(NoResolvedResultException.class);
-            Maven.configureResolver().workOffline().loadPomFromClassLoaderResource(pomFile).importRuntimeDependencies().resolve()
-                    .withTransitivity().as(File.class);
+            Maven.configureResolver().workOffline().loadPomFromClassLoaderResource(pomFile)
+                    .importCompileAndRuntimeDependencies()
+                    .resolve().withTransitivity().as(File.class);
         } finally {
             System.clearProperty(MavenSettingsBuilder.ALT_LOCAL_REPOSITORY_LOCATION);
         }

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/PomDependenciesUnitTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/PomDependenciesUnitTestCase.java
@@ -186,7 +186,8 @@ public class PomDependenciesUnitTestCase {
     @Test
     public void pomBasedDependencies() {
 
-        File[] files = Maven.resolver().loadPomFromFile("target/poms/test-child.xml").importRuntimeDependencies()
+        File[] files = Maven.resolver().loadPomFromFile("target/poms/test-child.xml")
+                .importCompileAndRuntimeDependencies()
                 .resolve().withTransitivity().as(File.class);
 
         ValidationUtil.fromDependencyTree(new File("src/test/resources/dependency-trees/test-child.tree"), false,
@@ -233,7 +234,8 @@ public class PomDependenciesUnitTestCase {
     public void pomRemoteBasedDependencies() {
 
         File[] files = Maven.resolver().loadPomFromFile("target/poms/test-remote-child.xml")
-                .importRuntimeDependencies().resolve().withTransitivity().as(File.class);
+                .importCompileAndRuntimeDependencies()
+                .resolve().withTransitivity().as(File.class);
 
         ValidationUtil.fromDependencyTree(new File("src/test/resources/dependency-trees/test-remote-child.tree"),
                 false, ScopeType.COMPILE, ScopeType.RUNTIME).validate(files);
@@ -260,7 +262,10 @@ public class PomDependenciesUnitTestCase {
                 .loadPomFromFile("target/poms/test-dependency-scopes.xml")
                 .importRuntimeDependencies().resolve().withTransitivity().as(File.class);
 
-        new ValidationUtil("test-deps-a", "test-deps-i", "test-deps-g", "test-deps-h").validate(files);
+        // test-deps-g is a runtime dependency of test-dependency-scopes. test-deps-h is a compile dependency of
+        // test-deps-g, which makes it also a runtime dependency of test-dependency-scopes, see the table at
+        // https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope
+        new ValidationUtil("test-deps-g", "test-deps-h").validate(files);
     }
 
     @Test

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/PomFilteringUnitTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/PomFilteringUnitTestCase.java
@@ -45,7 +45,9 @@ public class PomFilteringUnitTestCase {
     @Test
     public void testIncludeFromPomWithExclusionFilter() {
         final File[] jars = Maven.resolver().loadPomFromFile("target/poms/test-filter.xml")
-            .importRuntimeDependencies().resolve().using(new RejectDependenciesStrategy("org.jboss.shrinkwrap.test:test-deps-c"))
+            .importCompileAndRuntimeDependencies()
+            .resolve()
+            .using(new RejectDependenciesStrategy("org.jboss.shrinkwrap.test:test-deps-c"))
             .as(File.class);
 
         // We should not bring in b and c, as b is transitive from c, and we excluded c above.
@@ -56,10 +58,9 @@ public class PomFilteringUnitTestCase {
     @Test
     public void testIncludeFromPomWithExclusionsFilter() {
 
-        final File jar = Maven
-            .resolver()
-            .loadPomFromFile("target/poms/test-filter.xml")
-            .importRuntimeDependencies().resolve()
+        final File jar = Maven.resolver().loadPomFromFile("target/poms/test-filter.xml")
+            .importCompileAndRuntimeDependencies()
+            .resolve()
             .using(
                     // because RejectDependenciesStrategy is rejectTranstivites by default, we remove all mentioned nedpendencies 
                     // and their possible ancestors in dependency graph

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/PomTransitivesUnitTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/PomTransitivesUnitTestCase.java
@@ -56,7 +56,8 @@ public class PomTransitivesUnitTestCase {
 
         // FIXME for some reason transitive dependencies defined in <dependencyManagement> section are not honored
         File[] files = Resolvers.use(MavenResolverSystem.class)
-            .loadPomFromFile("target/poms/test-depmngmt-transitive.xml").importRuntimeDependencies().resolve().withTransitivity().as(File.class);
+            .loadPomFromFile("target/poms/test-depmngmt-transitive.xml")
+            .importCompileAndRuntimeDependencies().resolve().withTransitivity().as(File.class);
 
         Assert.assertEquals("Exactly 2 files were resolved", 2, files.length);
         new ValidationUtil("test-deps-b-2.0.0", "test-deps-c-1.0.0").validate(files);
@@ -70,8 +71,9 @@ public class PomTransitivesUnitTestCase {
     public void parentVersionInDependencyManagementByProperty() {
 
      // FIXME for some reason transitive dependencies defined in <dependencyManagement> section are not honored
-        File[] files = Resolvers.use(MavenResolverSystem.class).loadPomFromFile("target/poms/test-child-depmngmt.xml")
-            .importRuntimeDependencies().resolve().withTransitivity().as(File.class);
+        File[] files = Resolvers.use(MavenResolverSystem.class)
+            .loadPomFromFile("target/poms/test-child-depmngmt.xml")
+            .importCompileAndRuntimeDependencies().resolve().withTransitivity().as(File.class);
 
         new ValidationUtil("test-deps-j-1.0.0", "test-managed-dependency-2.0.0").validate(files);
 

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/ProfilesUnitTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/ProfilesUnitTestCase.java
@@ -116,8 +116,11 @@ public class ProfilesUnitTestCase {
     public void testProfileSelection1() {
 
         File[] files = Resolvers.use(MavenResolverSystem.class)
-                .loadPomFromFile("target/poms/test-profiles.xml", "version1").importRuntimeDependencies().resolve()
-                .withTransitivity().as(File.class);
+                .loadPomFromFile("target/poms/test-profiles.xml", "version1")
+                .importCompileAndRuntimeDependencies()
+                .resolve()
+                .withTransitivity()
+                .as(File.class);
 
         new ValidationUtil("test-deps-a-1.0.0", "test-managed-dependency-1.0.0").validate(files);
     }
@@ -126,8 +129,11 @@ public class ProfilesUnitTestCase {
     public void testProfileSelection2() {
 
         File[] files = Resolvers.use(MavenResolverSystem.class)
-                .loadPomFromFile("target/poms/test-profiles.xml", "version2").importRuntimeDependencies().resolve()
-                .withTransitivity().as(File.class);
+                .loadPomFromFile("target/poms/test-profiles.xml", "version2")
+                .importCompileAndRuntimeDependencies()
+                .resolve()
+                .withTransitivity()
+                .as(File.class);
 
         new ValidationUtil("test-deps-d-1.0.0", "test-managed-dependency-2.0.0").validate(files);
     }
@@ -136,7 +142,9 @@ public class ProfilesUnitTestCase {
     public void testActiveProfileByFile() {
 
         File[] files = Resolvers.use(MavenResolverSystem.class)
-                .loadPomFromFile("target/poms/test-profiles-file-activation.xml").importRuntimeDependencies().resolve()
+                .loadPomFromFile("target/poms/test-profiles-file-activation.xml")
+                .importCompileAndRuntimeDependencies()
+                .resolve()
                 .withTransitivity()
                 .as(File.class);
 
@@ -148,7 +156,10 @@ public class ProfilesUnitTestCase {
 
         File[] files = Resolvers.use(MavenResolverSystem.class)
                 .loadPomFromFile("target/poms/test-profiles-file-activation.xml", "!add-dependency-a")
-                .importRuntimeDependencies().resolve().withTransitivity().as(File.class);
+                .importCompileAndRuntimeDependencies()
+                .resolve()
+                .withTransitivity()
+                .as(File.class);
 
         new ValidationUtil("test-deps-d-1.0.0").validate(files);
     }

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/SpringTransitivityTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/SpringTransitivityTestCase.java
@@ -17,8 +17,11 @@ public class SpringTransitivityTestCase {
     @Test
     public void testVersionOfAOP() {
         File[] libs =
-            Maven.resolver().loadPomFromFile("target/poms/test-spring.xml").importRuntimeAndTestDependencies().resolve()
-                .withTransitivity().asFile();
+            Maven.resolver().loadPomFromFile("target/poms/test-spring.xml")
+                .importCompileAndRuntimeDependencies()
+                .resolve()
+                .withTransitivity()
+                .asFile();
 
         boolean found = false;
         for (File file : libs){

--- a/maven/maven-plugin/src/it/context-propagation/src/test/java/org/jboss/shrinkwrap/resolver/plugin/test/PluginIntegrationTestCase.java
+++ b/maven/maven-plugin/src/it/context-propagation/src/test/java/org/jboss/shrinkwrap/resolver/plugin/test/PluginIntegrationTestCase.java
@@ -39,7 +39,9 @@ public class PluginIntegrationTestCase {
     public void strictlyLoadTestDependencies() {
         PomEquippedResolveStage resolver = Maven.configureResolverViaPlugin();
 
-        final File[] files = resolver.importRuntimeDependencies().resolve().withoutTransitivity().as(File.class);
+        final File[] files = resolver.importCompileAndRuntimeDependencies()
+                .resolve().withoutTransitivity().as(File.class);
+
         new ValidationUtil("junit").validate(files);
     }
 


### PR DESCRIPTION
Asking for runtime dependencies should not include compile dependencies as these scopes are distinct.

This PR is more or less an RFC as I don't believe it would be merged as-is as it changes the current behavior. While I'm maybe missing something, I believe also the other convenience methods to import dependencies partly do the wrong thing.

Any comment as to why that is?