### PR TITLE
Fix removeDoubledSeparator()

### DIFF
--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/DefaultSettingsXmlLocationTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/DefaultSettingsXmlLocationTestCase.java
@@ -72,7 +72,7 @@ public class DefaultSettingsXmlLocationTestCase {
     }
 
     private String removeDoubledSeparator(String path){
-        return path.replaceAll(File.separator + File.separator, File.separator);
+        return path.replace(File.separator + File.separator, File.separator);
     }
 
     // this is calling internal private method that handles logic of settings.xml setup


### PR DESCRIPTION
replaceAll() takes a regex, but we do not provide one. Use replace()
instead, which despite its name also replaces all matching substrings.