### PR TITLE
Added support for running maven builds as a daemon

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -564,7 +564,6 @@ builtProject.getModule(String moduleName)
 ....
 There are several other useful methods provided by this Java class. For more information see link:/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/BuiltProject.java[BuiltProject]
 
-
 === Examples
 First example is just package a project and get the default archive:
 [source,java]
@@ -604,6 +603,30 @@ EmbeddedMaven
     .build();
 ....
 Some additional examples can be found in integration tests link:/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped[here] and link:/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped[here].
+
+
+=== Daemon build
+In some cases, you need to run a Maven build in the background. The first case is when the build itself starts some application (eg. `mvn spring-boot:run`). The second case is when you are building a project that is too big so can do some other operation in the meantime let the Maven built run in the background.
+In these cases you can specify that the build should be used as a daemon, which means that ShrinkWrap Resolver runs the build in a new separated thread:
+[source,java]
+....
+EmbeddedMaven.forProject("path/to/pom.xml").setGoals("spring-boot:run").useAsDaemon().build();
+....
+In the case of running some application using the Maven build, it could be useful to wait till the application is started. To do so, use one of the methods:
+[source,java]
+....
+...useAsDaemon().withWaitUntilOutputLineMathes(".*Started Application.*").build();
+...useAsDaemon().withWaitUntilOutputLineMathes(".*Started Application.*", 50, TimeUnit.SECONDS).build();
+....
+In the first case, it waits until some line matches the given regex. If there is no line matched within the default timeout (which is two minutes) then TimeoutException is thrown.
+The second case is the same but it sets the timeout to given value.
+ShrinkWrap Resolver stops the main thread and waits until some line matches the given regex and then continues. The build itself continues running as well.
+
+In the case you need to build a huge project and let it run on the background and then come back to it later, you can use the object `DaemonBuild` that is returned by the method `build()`:
+....
+DaemonBuild build = EmbeddedMaven.forProject("path/to/pom.xml").setGoals("package").useAsDaemon().build();
+....
+This object offers a methods `isAlive()` that says if the thread containing the Maven build is alive or not; and a method `getBuiltProject()` that returns an instance of `BuiltProject` when the thread is not alive, `null` otherwise.
 
 
 == Experimental features

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/BuildStage.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/BuildStage.java
@@ -17,31 +17,13 @@
 
 package org.jboss.shrinkwrap.resolver.api.maven.embedded;
 
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigger;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuilder;
+
 /**
  * @author <a href="mailto:mjobanek@gmail.com">Matous Jobanek</a>
  */
-public interface BuildStage {
-
-    /**
-     * Build project using previously configured project data and environment settings.
-     *
-     * @return An instance of @{BuiltProject} as a representation of the built project
-     */
-    BuiltProject build();
-
-    /**
-     * If a failure of a project maven build should be ignored. Default is <code>false</code>
-     *
-     * @param ignoreFailure If a failure of a project maven build should be ignored
-     * @return Modified EmbeddedMaven instance
-     */
-    BuildStage ignoreFailure(boolean ignoreFailure);
-
-    /**
-     * Sets that a failure of a project maven build should be ignored.
-     *
-     * @return Modified EmbeddedMaven instance
-     */
-    BuildStage ignoreFailure();
+public interface BuildStage<DAEMON_TRIGGER_TYPE extends DaemonBuildTrigger>
+    extends StandardBuilder, DaemonBuilder<DAEMON_TRIGGER_TYPE> {
 
 }

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/DistributionStage.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/DistributionStage.java
@@ -19,11 +19,13 @@ package org.jboss.shrinkwrap.resolver.api.maven.embedded;
 
 import java.io.File;
 import java.net.URL;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigger;
 
 /**
  * @author <a href="mailto:mjobanek@gmail.com">Matous Jobanek</a>
  */
-public interface DistributionStage<NEXT_STEP extends BuildStage> extends BuildStage{
+public interface DistributionStage<NEXT_STEP extends BuildStage<DAEMON_TRIGGER_TYPE>, DAEMON_TRIGGER_TYPE extends DaemonBuildTrigger>
+    extends BuildStage<DAEMON_TRIGGER_TYPE> {
 
     /**
      * Configures EmbeddedMaven to build project with Maven 3 of given version. If the zip file is not cached in directory

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/StandardBuilder.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/StandardBuilder.java
@@ -1,0 +1,26 @@
+package org.jboss.shrinkwrap.resolver.api.maven.embedded;
+
+public interface StandardBuilder {
+
+    /**
+     * Build project using previously configured project data and environment settings.
+     *
+     * @return An instance of @{BuiltProject} as a representation of the built project
+     */
+    BuiltProject build();
+
+    /**
+     * If a failure of a project maven build should be ignored. Default is <code>false</code>
+     *
+     * @param ignoreFailure If a failure of a project maven build should be ignored
+     * @return Modified EmbeddedMaven instance
+     */
+    StandardBuilder ignoreFailure(boolean ignoreFailure);
+
+    /**
+     * Sets that a failure of a project maven build should be ignored.
+     *
+     * @return Modified EmbeddedMaven instance
+     */
+    StandardBuilder ignoreFailure();
+}

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuild.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuild.java
@@ -1,0 +1,26 @@
+package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
+
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
+
+/**
+ * A representation of the daemon Maven build
+ */
+public interface DaemonBuild {
+
+    /**
+     * Checks if this thread containing the Maven build is alive.
+     *
+     * @return <code>true</code> if the thread containing the Maven build  is alive;
+     * <code>false</code> otherwise.
+     */
+    boolean isAlive();
+
+    /**
+     * If the thread containing the Maven build is not alive, then it returns an instance of @{BuiltProject} as a
+     * representation of the built project; {@code null} otherwise
+     *
+     * @return If Maven build is not alive then an instance of @{BuiltProject} as a representation of the built project;
+     * {@code null} otherwise
+     */
+    BuiltProject getBuiltProject();
+}

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuildTrigger.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuildTrigger.java
@@ -1,11 +1,4 @@
 package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
 
-import java.util.concurrent.TimeoutException;
-
 public interface DaemonBuildTrigger {
-
-    /**
-     * Triggers a build  of the project using previously configured project data and environment settings.
-     */
-    void build() throws TimeoutException;
 }

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuildTrigger.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuildTrigger.java
@@ -1,0 +1,11 @@
+package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
+
+import java.util.concurrent.TimeoutException;
+
+public interface DaemonBuildTrigger {
+
+    /**
+     * Triggers a build  of the project using previously configured project data and environment settings.
+     */
+    void build() throws TimeoutException;
+}

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuildTriggerWithTimeout.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuildTriggerWithTimeout.java
@@ -1,0 +1,14 @@
+package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
+
+import java.util.concurrent.TimeoutException;
+
+public interface DaemonBuildTriggerWithTimeout extends DaemonBuildTrigger {
+
+    /**
+     * Triggers a build  of the project using previously configured project data and environment settings.
+     *
+     * @return An instance of {@link DaemonBuild} as a representation of the daemon Maven build.
+     * @throws TimeoutException if the previously set condition hasn't been met within the set timeout.
+     */
+    DaemonBuild build() throws TimeoutException;
+}

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuildTriggerWithoutTimeout.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuildTriggerWithoutTimeout.java
@@ -1,0 +1,11 @@
+package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
+
+public interface DaemonBuildTriggerWithoutTimeout extends DaemonBuildTrigger {
+
+    /**
+     * Triggers a build  of the project using previously configured project data and environment settings.
+     *
+     * @return An instance of {@link DaemonBuild} as a representation of the daemon Maven build.
+     */
+    DaemonBuild build();
+}

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuilder.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/DaemonBuilder.java
@@ -1,0 +1,11 @@
+package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
+
+public interface DaemonBuilder<DAEMON_TRIGGER_TYPE extends DaemonBuildTrigger> {
+
+    /**
+     * Ensures that the build of the project will be triggered in separated thread.
+     *
+     * @return Instance of some implementation of {@link DaemonBuildTrigger}
+     */
+    DAEMON_TRIGGER_TYPE useAsDaemon();
+}

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/WithTimeoutDaemonBuilder.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/WithTimeoutDaemonBuilder.java
@@ -1,0 +1,27 @@
+package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public interface WithTimeoutDaemonBuilder extends DaemonBuildTrigger {
+
+    /**
+     * Resolver will wait until the specified regex matches some line of the build output.
+     * If the output is not present within two minutes, then {@link TimeoutException} is thrown
+     *
+     * @param regex Regex a line of the build output should match
+     * @return An instance of {@link DaemonBuildTrigger}
+     */
+    DaemonBuildTrigger withWaitUntilOutputLineMathes(String regex);
+
+    /**
+     * Resolver will wait until the specified regex matches some line of the build output.
+     * If the output is not present within the given time, then {@link TimeoutException} is thrown
+     *
+     * @param regex Regex a line of the build output should match
+     * @param timeout the maximum time to wait
+     * @param timeoutUnit the time unit of the {@code timeout} argument
+     * @return An instance of {@link DaemonBuildTrigger}
+     */
+    DaemonBuildTrigger withWaitUntilOutputLineMathes(String regex, long timeout, TimeUnit timeoutUnit);
+}

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/WithTimeoutDaemonBuilder.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/WithTimeoutDaemonBuilder.java
@@ -3,16 +3,16 @@ package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public interface WithTimeoutDaemonBuilder extends DaemonBuildTrigger {
+public interface WithTimeoutDaemonBuilder extends DaemonBuildTriggerWithoutTimeout {
 
     /**
      * Resolver will wait until the specified regex matches some line of the build output.
      * If the output is not present within two minutes, then {@link TimeoutException} is thrown
      *
      * @param regex Regex a line of the build output should match
-     * @return An instance of {@link DaemonBuildTrigger}
+     * @return An instance of {@link DaemonBuildTriggerWithTimeout}
      */
-    DaemonBuildTrigger withWaitUntilOutputLineMathes(String regex);
+    DaemonBuildTriggerWithTimeout withWaitUntilOutputLineMathes(String regex);
 
     /**
      * Resolver will wait until the specified regex matches some line of the build output.
@@ -21,7 +21,7 @@ public interface WithTimeoutDaemonBuilder extends DaemonBuildTrigger {
      * @param regex Regex a line of the build output should match
      * @param timeout the maximum time to wait
      * @param timeoutUnit the time unit of the {@code timeout} argument
-     * @return An instance of {@link DaemonBuildTrigger}
+     * @return An instance of {@link DaemonBuildTriggerWithTimeout}
      */
-    DaemonBuildTrigger withWaitUntilOutputLineMathes(String regex, long timeout, TimeUnit timeoutUnit);
+    DaemonBuildTriggerWithTimeout withWaitUntilOutputLineMathes(String regex, long timeout, TimeUnit timeoutUnit);
 }

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/WithoutTimeoutDaemonBuilder.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/WithoutTimeoutDaemonBuilder.java
@@ -1,4 +1,4 @@
 package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
 
-public interface WithoutTimeoutDaemonBuilder extends DaemonBuildTrigger {
+public interface WithoutTimeoutDaemonBuilder extends DaemonBuildTriggerWithoutTimeout {
 }

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/WithoutTimeoutDaemonBuilder.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/daemon/WithoutTimeoutDaemonBuilder.java
@@ -1,0 +1,4 @@
+package org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon;
+
+public interface WithoutTimeoutDaemonBuilder extends DaemonBuildTrigger {
+}

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/invoker/equipped/MavenInvokerEquippedEmbeddedMaven.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/invoker/equipped/MavenInvokerEquippedEmbeddedMaven.java
@@ -19,9 +19,11 @@ package org.jboss.shrinkwrap.resolver.api.maven.embedded.invoker.equipped;
 
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuildStage;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.DistributionStage;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithoutTimeoutDaemonBuilder;
 
 /**
  * @author <a href="mailto:mjobanek@gmail.com">Matous Jobanek</a>
  */
-public interface MavenInvokerEquippedEmbeddedMaven extends DistributionStage<BuildStage> {
+public interface MavenInvokerEquippedEmbeddedMaven
+    extends DistributionStage<BuildStage<WithoutTimeoutDaemonBuilder>, WithoutTimeoutDaemonBuilder> {
 }

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/pom/equipped/ConfigurationDistributionStage.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/pom/equipped/ConfigurationDistributionStage.java
@@ -1,10 +1,12 @@
 package org.jboss.shrinkwrap.resolver.api.maven.embedded.pom.equipped;
 
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.DistributionStage;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithTimeoutDaemonBuilder;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
 public interface ConfigurationDistributionStage
-    extends ConfigurationStage<ConfigurationDistributionStage>, DistributionStage<ConfigurationStage> {
+    extends ConfigurationStage<ConfigurationDistributionStage, WithTimeoutDaemonBuilder>,
+    DistributionStage<ConfigurationStage<ConfigurationDistributionStage, WithTimeoutDaemonBuilder>, WithTimeoutDaemonBuilder> {
 }

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/pom/equipped/ConfigurationStage.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/pom/equipped/ConfigurationStage.java
@@ -21,15 +21,16 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Properties;
-
 import org.apache.maven.shared.invoker.InvokerLogger;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuildStage;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigger;
 
 /**
  * @author <a href="mailto:mjobanek@gmail.com">Matous Jobanek</a>
  */
-public interface ConfigurationStage<DIST_OR_CONFIG extends ConfigurationStage> extends BuildStage {
+public interface ConfigurationStage<DIST_OR_CONFIG extends ConfigurationStage, DAEMON_TRIGGER_TYPE extends DaemonBuildTrigger>
+    extends BuildStage<DAEMON_TRIGGER_TYPE> {
 
      /**
       * Sets the interaction mode of the Maven invocation. Inverse equivalent of -B and --batch-mode

--- a/maven/impl-maven-embedded/pom.xml
+++ b/maven/impl-maven-embedded/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <version.maven.invoker>2.2</version.maven.invoker>
         <version.arquillian.spacelift>1.0.0.Alpha8</version.arquillian.spacelift>
-        <version.assertj>3.6.2</version.assertj>
+        <version.assertj>2.7.0</version.assertj>
     </properties>
 
     <dependencies>

--- a/maven/impl-maven-embedded/pom.xml
+++ b/maven/impl-maven-embedded/pom.xml
@@ -17,6 +17,7 @@
         <version.maven.invoker>2.2</version.maven.invoker>
         <version.arquillian.spacelift>1.0.0.Alpha8</version.arquillian.spacelift>
         <version.assertj>2.7.0</version.assertj>
+        <version.awaitility>3.0.0</version.awaitility>
     </properties>
 
     <dependencies>
@@ -68,6 +69,12 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${version.assertj}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${version.awaitility}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/maven/impl-maven-embedded/pom.xml
+++ b/maven/impl-maven-embedded/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <version.maven.invoker>2.2</version.maven.invoker>
         <version.arquillian.spacelift>1.0.0.Alpha8</version.arquillian.spacelift>
+        <version.assertj>3.6.2</version.assertj>
     </properties>
 
     <dependencies>
@@ -61,6 +62,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${version.assertj}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildStageImpl.java
@@ -29,8 +29,7 @@ public abstract class BuildStageImpl<NEXT_STEP extends BuildStage<DAEMON_TRIGGER
 
     @Override
     public StandardBuilder ignoreFailure() {
-        ignoreFailure = true;
-        return this;
+        return ignoreFailure(true);
     }
 
     @Override

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildStageImpl.java
@@ -1,127 +1,50 @@
 package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
 
-import java.io.File;
-import java.util.List;
-import java.util.logging.Logger;
-
 import org.apache.maven.shared.invoker.InvocationRequest;
-import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.Invoker;
-import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuildStage;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.StandardBuilder;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigger;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
-public abstract class BuildStageImpl<NEXT_STEP extends BuildStage> extends DistributionStageImpl<NEXT_STEP>
-    implements BuildStage {
-
-    private static Logger log = Logger.getLogger(BuildStageImpl.class.getName());
-    private static final String SAX_PARSER_FACTORY_KEY = "javax.xml.parsers.SAXParserFactory";
+public abstract class BuildStageImpl<NEXT_STEP extends BuildStage<DAEMON_TRIGGER_TYPE>, DAEMON_TRIGGER_TYPE extends DaemonBuildTrigger>
+    extends DistributionStageImpl<NEXT_STEP, DAEMON_TRIGGER_TYPE> implements BuildStage<DAEMON_TRIGGER_TYPE> {
 
     private boolean ignoreFailure = false;
 
     @Override
     public BuiltProject build() {
-        final String oldValue = removeSAXParserFactoryProperty();
-
-        if (getSetMavenInstalation() != null) {
-            getInvoker().setMavenHome(getSetMavenInstalation());
-        }
-
-        InvocationResult result = null;
-        try {
-
-            printStatus("started");
-
-            result = getInvoker().execute(getInvocationRequest());
-
-            if (result.getExitCode() != 0) {
-                if (ignoreFailure) {
-                    log.severe("Maven build failed - the exit code is: " + result.getExitCode());
-                } else {
-                    throw new IllegalStateException("Maven build failed - the exit code is: " + result.getExitCode()
-                                                        + "\n To ignore this failure use method ignoreFailure()",
-                                                    result.getExecutionException());
-                }
-            }
-
-        } catch (MavenInvocationException e) {
-            throw new IllegalStateException("Execution of a Maven build has failed", e);
-        } finally {
-            printStatus("stopped");
-        }
-        setSAXParserFactoryProperty(oldValue);
-
-        return getBuiltProject(result);
+        return createBuildTrigger().build(null, null);
     }
 
-    private void printStatus(String status) {
-        File pomFile = getInvocationRequest().getPomFile();
-        String projectPom = "";
-
-        if (pomFile == null) {
-            File baseDirectory = getInvocationRequest().getBaseDirectory();
-            if (baseDirectory != null) {
-                projectPom = baseDirectory.getName() + File.separator;
-            }
-            String pomFileName = getInvocationRequest().getPomFileName();
-            if (pomFileName != null) {
-                projectPom = projectPom + pomFileName;
-            }
-        } else {
-            projectPom = pomFile.getParentFile().getName() + File.separator + pomFile.getName();
-        }
-        StringBuffer borders = new StringBuffer("==========================================");
-        for (int i = 0; i < projectPom.length(); i++) {
-            borders.append("=");
-        }
-        System.out.println(borders.toString());
-        System.out.println("===   Embedded Maven build " + status + ": " + projectPom + "   ===");
-        System.out.println(borders.toString());
-    }
-
-    public BuildStage ignoreFailure(boolean ignoreFailure) {
+    @Override
+    public StandardBuilder ignoreFailure(boolean ignoreFailure) {
         this.ignoreFailure = ignoreFailure;
         return this;
     }
 
-    public BuildStage ignoreFailure() {
-        this.ignoreFailure = true;
+    @Override
+    public StandardBuilder ignoreFailure() {
+        ignoreFailure = true;
         return this;
     }
 
-    private BuiltProject getBuiltProject(InvocationResult result) {
-        File pomFile = getInvocationRequest().getPomFile();
-        if (pomFile == null){
-            pomFile = new File(getInvocationRequest().getBaseDirectory() + File.separator + "pom.xml");
-        }
-        BuiltProjectImpl builtProject = new BuiltProjectImpl(
-            pomFile,
-            getInvocationRequest().getGlobalSettingsFile(),
-            getInvocationRequest().getUserSettingsFile(),
-            getInvocationRequest().getProperties(),
-            profilesInArray());
-
-        if (getLogBuffer() != null) {
-            builtProject.setMavenLog(getLogBuffer().toString());
-        }
-        if (result != null){
-            builtProject.setMavenBuildExitCode(result.getExitCode());
-        }
-
-        return builtProject;
+    @Override
+    public DAEMON_TRIGGER_TYPE useAsDaemon() {
+        return (DAEMON_TRIGGER_TYPE) new DaemonBuildTriggerImpl(createBuildTrigger());
     }
 
-    private String[] profilesInArray() {
-        String[] profiles = new String[] {};
-        List<String> profilesList = getInvocationRequest().getProfiles();
-        if (profilesList != null) {
-            profiles = new String[profilesList.size()];
-            profiles = profilesList.toArray(profiles);
-        }
-        return profiles;
+    private BuildTrigger createBuildTrigger(){
+        return new BuildTrigger(
+            getSetMavenInstallation(),
+            getInvocationRequest(),
+            getInvoker(),
+            getLogBuffer(),
+            isQuiet(),
+            ignoreFailure);
     }
 
     protected abstract InvocationRequest getInvocationRequest();
@@ -130,15 +53,5 @@ public abstract class BuildStageImpl<NEXT_STEP extends BuildStage> extends Distr
 
     protected abstract StringBuffer getLogBuffer();
 
-    private String removeSAXParserFactoryProperty() {
-        // solution for https://issues.jboss.org/browse/SHRINKRES-212
-        final Object value = System.getProperties().remove(SAX_PARSER_FACTORY_KEY);
-        return value != null ? (String) value : null;
-    }
-
-    private void setSAXParserFactoryProperty(String oldValue) {
-        if (oldValue != null) {
-            System.setProperty(SAX_PARSER_FACTORY_KEY, oldValue);
-        }
-    }
+    protected abstract boolean isQuiet();
 }

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildStageImpl.java
@@ -6,6 +6,7 @@ import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuildStage;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.StandardBuilder;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigger;
+import org.jboss.shrinkwrap.resolver.impl.maven.embedded.daemon.DaemonBuildTriggerImpl;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildTrigger.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildTrigger.java
@@ -1,0 +1,156 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Logger;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
+import org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped.ResolverErrorOutputHandler;
+import org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped.ResolverOutputHandler;
+
+public class BuildTrigger {
+
+    private final String SAX_PARSER_FACTORY_KEY = "javax.xml.parsers.SAXParserFactory";
+    private final Logger log = Logger.getLogger(BuildStageImpl.class.getName());
+    private final boolean ignoreFailure;
+    private final File mavenInstallation;
+    private final InvocationRequest invocationRequest;
+    private final Invoker invoker;
+    private final StringBuffer logBuffer;
+    private boolean quiet;
+
+    public BuildTrigger(File mavenInstallation, InvocationRequest invocationRequest, Invoker invoker,
+        StringBuffer logBuffer, boolean quiet, boolean ignoreFailure) {
+        this.mavenInstallation = mavenInstallation;
+        this.invocationRequest = invocationRequest;
+        this.invoker = invoker;
+        this.logBuffer = logBuffer;
+        this.quiet = quiet;
+        this.ignoreFailure = ignoreFailure;
+    }
+
+    private void setOutputHandlers(String expectedRegex, CountDownLatch countDownLatch) {
+        if (logBuffer != null) {
+            ResolverErrorOutputHandler errorOutputHandler =
+                new ResolverErrorOutputHandler(logBuffer, expectedRegex, countDownLatch);
+            ResolverOutputHandler outputHandler = new ResolverOutputHandler(logBuffer, expectedRegex, countDownLatch);
+
+            invoker.setOutputHandler(outputHandler);
+            invocationRequest.setOutputHandler(outputHandler);
+
+            invoker.setErrorHandler(errorOutputHandler);
+            invocationRequest.setErrorHandler(errorOutputHandler);
+
+            errorOutputHandler.setQuiet(quiet);
+            outputHandler.setQuiet(quiet);
+        }
+    }
+
+    public BuiltProject build(String expectedRegex, CountDownLatch countDownLatch) {
+        final String oldValue = removeSAXParserFactoryProperty();
+
+        if (mavenInstallation != null) {
+            invoker.setMavenHome(mavenInstallation);
+        }
+
+        setOutputHandlers(expectedRegex, countDownLatch);
+
+        InvocationResult result = null;
+        try {
+
+            printStatus("started");
+
+            result = invoker.execute(invocationRequest);
+
+            if (result.getExitCode() != 0) {
+                if (ignoreFailure) {
+                    log.severe("Maven build failed - the exit code is: " + result.getExitCode());
+                } else {
+                    throw new IllegalStateException("Maven build failed - the exit code is: " + result.getExitCode()
+                        + "\n To ignore this failure use method ignoreFailure()",
+                        result.getExecutionException());
+                }
+            }
+        } catch (MavenInvocationException e) {
+            throw new IllegalStateException("Execution of a Maven build has failed", e);
+        } finally {
+            printStatus("stopped");
+        }
+        setSAXParserFactoryProperty(oldValue);
+
+        return getBuiltProject(result);
+    }
+
+    private void printStatus(String status) {
+        File pomFile = invocationRequest.getPomFile();
+        String projectPom = "";
+
+        if (pomFile == null) {
+            File baseDirectory = invocationRequest.getBaseDirectory();
+            if (baseDirectory != null) {
+                projectPom = baseDirectory.getName() + File.separator;
+            }
+            String pomFileName = invocationRequest.getPomFileName();
+            if (pomFileName != null) {
+                projectPom = projectPom + pomFileName;
+            }
+        } else {
+            projectPom = pomFile.getParentFile().getName() + File.separator + pomFile.getName();
+        }
+        StringBuffer borders = new StringBuffer("==========================================");
+        for (int i = 0; i < projectPom.length(); i++) {
+            borders.append("=");
+        }
+        System.out.println(borders.toString());
+        System.out.println("===   Embedded Maven build " + status + ": " + projectPom + "   ===");
+        System.out.println(borders.toString());
+    }
+
+    private BuiltProject getBuiltProject(InvocationResult result) {
+        File pomFile = invocationRequest.getPomFile();
+        if (pomFile == null) {
+            pomFile = new File(invocationRequest.getBaseDirectory() + File.separator + "pom.xml");
+        }
+        BuiltProjectImpl builtProject = new BuiltProjectImpl(
+            pomFile,
+            invocationRequest.getGlobalSettingsFile(),
+            invocationRequest.getUserSettingsFile(),
+            invocationRequest.getProperties(),
+            profilesInArray());
+
+        if (logBuffer != null) {
+            builtProject.setMavenLog(logBuffer.toString());
+        }
+        if (result != null) {
+            builtProject.setMavenBuildExitCode(result.getExitCode());
+        }
+
+        return builtProject;
+    }
+
+    private String[] profilesInArray() {
+        String[] profiles = new String[] {};
+        List<String> profilesList = invocationRequest.getProfiles();
+        if (profilesList != null) {
+            profiles = new String[profilesList.size()];
+            profiles = profilesList.toArray(profiles);
+        }
+        return profiles;
+    }
+
+    private String removeSAXParserFactoryProperty() {
+        // solution for https://issues.jboss.org/browse/SHRINKRES-212
+        final Object value = System.getProperties().remove(SAX_PARSER_FACTORY_KEY);
+        return value != null ? (String) value : null;
+    }
+
+    private void setSAXParserFactoryProperty(String oldValue) {
+        if (oldValue != null) {
+            System.setProperty(SAX_PARSER_FACTORY_KEY, oldValue);
+        }
+    }
+}

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DaemonBuildImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DaemonBuildImpl.java
@@ -1,0 +1,76 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
+
+import java.util.concurrent.CountDownLatch;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuild;
+
+public class DaemonBuildImpl implements DaemonBuild {
+
+    private Thread daemonBuildThread;
+    private DaemonRunnable daemonRunnable;
+
+    public DaemonBuildImpl(BuildTrigger buildTrigger){
+        daemonRunnable = new DaemonRunnable(buildTrigger, null);
+    }
+
+    public DaemonBuildImpl(BuildTrigger buildTrigger, String expectedRegex){
+        daemonRunnable = new DaemonRunnable(buildTrigger, expectedRegex);
+    }
+
+    public boolean isAlive(){
+        return daemonBuildThread.isAlive();
+    }
+
+    public BuiltProject getBuiltProject(){
+        if (isAlive()){
+            return null;
+        } else {
+            return daemonRunnable.getBuiltProject();
+        }
+    }
+
+    public String getExpectedRegex() {
+        return daemonRunnable.getExpectedRegex();
+    }
+
+    DaemonBuild build(CountDownLatch countDownLatch) {
+        daemonRunnable.setCountDownLatch(countDownLatch);
+        return build();
+    }
+
+    DaemonBuild build() {
+        daemonBuildThread = new Thread(daemonRunnable);
+        daemonBuildThread.start();
+        return this;
+    }
+
+    private class DaemonRunnable implements Runnable {
+
+        private CountDownLatch countDownLatch;
+        private String expectedRegex;
+        private BuildTrigger buildTrigger;
+        private BuiltProject builtProject;
+
+        DaemonRunnable(BuildTrigger buildTrigger, String expectedRegex){
+            this.buildTrigger = buildTrigger;
+            this.expectedRegex = expectedRegex;
+        }
+
+        @Override
+        public void run() {
+            builtProject = buildTrigger.build(expectedRegex, countDownLatch);
+        }
+
+        BuiltProject getBuiltProject() {
+            return builtProject;
+        }
+
+        void setCountDownLatch(CountDownLatch countDownLatch){
+            this.countDownLatch = countDownLatch;
+        }
+
+        String getExpectedRegex() {
+            return expectedRegex;
+        }
+    }
+}

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DaemonBuildTriggerImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DaemonBuildTriggerImpl.java
@@ -3,55 +3,69 @@ package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigger;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuild;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTriggerWithTimeout;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTriggerWithoutTimeout;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithTimeoutDaemonBuilder;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithoutTimeoutDaemonBuilder;
 
-public class DaemonBuildTriggerImpl implements WithTimeoutDaemonBuilder, WithoutTimeoutDaemonBuilder {
+public class DaemonBuildTriggerImpl implements WithTimeoutDaemonBuilder, DaemonBuildTriggerWithoutTimeout,
+    WithoutTimeoutDaemonBuilder {
 
     private BuildTrigger buildTrigger;
-    private String expectedRegex;
-    private long timeout = 2;
-    private TimeUnit timeoutUnit = TimeUnit.MINUTES;
 
     public DaemonBuildTriggerImpl(BuildTrigger buildTrigger) {
         this.buildTrigger = buildTrigger;
     }
 
     @Override
-    public void build() throws TimeoutException {
-        int countDown = expectedRegex != null ? 1 : 0;
-        final CountDownLatch countDownLatch = new CountDownLatch(countDown);
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                buildTrigger.build(expectedRegex, countDownLatch);
+    public DaemonBuild build() {
+        return new DaemonBuildImpl(buildTrigger).build();
+    }
+
+    @Override
+    public DaemonBuildTriggerWithTimeout withWaitUntilOutputLineMathes(String expectedRegex) {
+        return new DaemonBuildTriggerWithTimeoutImpl(new DaemonBuildImpl(buildTrigger, expectedRegex));
+    }
+
+    @Override
+    public DaemonBuildTriggerWithTimeout withWaitUntilOutputLineMathes(String expectedRegex, long timeout,
+        TimeUnit timeoutUnit) {
+        return new DaemonBuildTriggerWithTimeoutImpl(new DaemonBuildImpl(buildTrigger, expectedRegex), timeout, timeoutUnit);
+    }
+
+    class DaemonBuildTriggerWithTimeoutImpl implements DaemonBuildTriggerWithTimeout {
+
+        private DaemonBuildImpl daemonBuild;
+        private long timeout = 2;
+        private TimeUnit timeoutUnit = TimeUnit.MINUTES;
+
+        DaemonBuildTriggerWithTimeoutImpl(DaemonBuildImpl daemonBuild) {
+            this.daemonBuild = daemonBuild;
+        }
+
+        DaemonBuildTriggerWithTimeoutImpl(DaemonBuildImpl daemonBuild, long timeout, TimeUnit timeoutUnit) {
+            this.daemonBuild = daemonBuild;
+            this.timeout = timeout;
+            this.timeoutUnit = timeoutUnit;
+        }
+
+        @Override
+        public DaemonBuild build() throws TimeoutException {
+            final CountDownLatch countDownLatch = new CountDownLatch(1);
+            DaemonBuild daemonBuild = this.daemonBuild.build(countDownLatch);
+            try {
+                countDownLatch.await(timeout, timeoutUnit);
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
             }
-        }).start();
-        try {
-            countDownLatch.await(timeout, timeoutUnit);
-        } catch (InterruptedException e) {
-            throw new IllegalStateException(e);
+            if (countDownLatch.getCount() > 0) {
+                String message = String.format(
+                    "The expected regex %s haven't matched any line of the build output within the time of %s %s",
+                    this.daemonBuild.getExpectedRegex(), timeout, timeoutUnit);
+                throw new TimeoutException(message);
+            }
+            return daemonBuild;
         }
-        if (countDownLatch.getCount() > 0){
-            String message = String.format(
-                "The expected regex %s haven't matched any line of the build output within the time of %s %s",
-                expectedRegex, timeout, timeoutUnit);
-            throw new TimeoutException(message);
-        }
-    }
-
-    @Override
-    public DaemonBuildTrigger withWaitUntilOutputLineMathes(String expectedRegex) {
-        this.expectedRegex = expectedRegex;
-        return this;
-    }
-
-    @Override
-    public DaemonBuildTrigger withWaitUntilOutputLineMathes(String expectedRegex, long timeout, TimeUnit timeoutUnit) {
-        this.expectedRegex = expectedRegex;
-        this.timeout = timeout;
-        this.timeoutUnit = timeoutUnit;
-        return this;
     }
 }

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DaemonBuildTriggerImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DaemonBuildTriggerImpl.java
@@ -1,0 +1,57 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigger;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithTimeoutDaemonBuilder;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithoutTimeoutDaemonBuilder;
+
+public class DaemonBuildTriggerImpl implements WithTimeoutDaemonBuilder, WithoutTimeoutDaemonBuilder {
+
+    private BuildTrigger buildTrigger;
+    private String expectedRegex;
+    private long timeout = 2;
+    private TimeUnit timeoutUnit = TimeUnit.MINUTES;
+
+    public DaemonBuildTriggerImpl(BuildTrigger buildTrigger) {
+        this.buildTrigger = buildTrigger;
+    }
+
+    @Override
+    public void build() throws TimeoutException {
+        int countDown = expectedRegex != null ? 1 : 0;
+        final CountDownLatch countDownLatch = new CountDownLatch(countDown);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildTrigger.build(expectedRegex, countDownLatch);
+            }
+        }).start();
+        try {
+            countDownLatch.await(timeout, timeoutUnit);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+        if (countDownLatch.getCount() > 0){
+            String message = String.format(
+                "The expected regex %s haven't matched any line of the build output within the time of %s %s",
+                expectedRegex, timeout, timeoutUnit);
+            throw new TimeoutException(message);
+        }
+    }
+
+    @Override
+    public DaemonBuildTrigger withWaitUntilOutputLineMathes(String expectedRegex) {
+        this.expectedRegex = expectedRegex;
+        return this;
+    }
+
+    @Override
+    public DaemonBuildTrigger withWaitUntilOutputLineMathes(String expectedRegex, long timeout, TimeUnit timeoutUnit) {
+        this.expectedRegex = expectedRegex;
+        this.timeout = timeout;
+        this.timeoutUnit = timeoutUnit;
+        return this;
+    }
+}

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DistributionStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DistributionStageImpl.java
@@ -1,5 +1,12 @@
 package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Logger;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.arquillian.spacelift.Spacelift;
 import org.arquillian.spacelift.execution.Execution;
@@ -9,20 +16,13 @@ import org.arquillian.spacelift.task.archive.UnzipTool;
 import org.arquillian.spacelift.task.net.DownloadTool;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuildStage;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.DistributionStage;
-
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.logging.Logger;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigger;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
-public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage>
-        implements DistributionStage<NEXT_STEP> {
+public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage<DAEMON_TRIGGER_TYPE>, DAEMON_TRIGGER_TYPE extends DaemonBuildTrigger>
+    implements DistributionStage<NEXT_STEP, DAEMON_TRIGGER_TYPE> {
 
     private String maven3BaseUrl =
             "https://archive.apache.org/dist/maven/maven-3/%version%/binaries/apache-maven-%version%-bin.tar.gz";
@@ -224,7 +224,7 @@ public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage>
         return returnNextStepType();
     }
 
-    protected File getSetMavenInstalation() {
+    protected File getSetMavenInstallation() {
         return setMavenInstalation;
     }
 

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/daemon/DaemonBuildImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/daemon/DaemonBuildImpl.java
@@ -1,8 +1,9 @@
-package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded.daemon;
 
 import java.util.concurrent.CountDownLatch;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuild;
+import org.jboss.shrinkwrap.resolver.impl.maven.embedded.BuildTrigger;
 
 public class DaemonBuildImpl implements DaemonBuild {
 

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/daemon/DaemonBuildTriggerImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/daemon/DaemonBuildTriggerImpl.java
@@ -1,4 +1,4 @@
-package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded.daemon;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -8,6 +8,7 @@ import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigge
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTriggerWithoutTimeout;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithTimeoutDaemonBuilder;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithoutTimeoutDaemonBuilder;
+import org.jboss.shrinkwrap.resolver.impl.maven.embedded.BuildTrigger;
 
 public class DaemonBuildTriggerImpl implements WithTimeoutDaemonBuilder, DaemonBuildTriggerWithoutTimeout,
     WithoutTimeoutDaemonBuilder {

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/MavenInvokerEquippedEmbeddedMavenImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/MavenInvokerEquippedEmbeddedMavenImpl.java
@@ -3,14 +3,16 @@ package org.jboss.shrinkwrap.resolver.impl.maven.embedded.invoker.equipped;
 import org.apache.maven.shared.invoker.InvocationRequest;
 import org.apache.maven.shared.invoker.Invoker;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuildStage;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithoutTimeoutDaemonBuilder;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.invoker.equipped.MavenInvokerEquippedEmbeddedMaven;
 import org.jboss.shrinkwrap.resolver.impl.maven.embedded.BuildStageImpl;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
-public class MavenInvokerEquippedEmbeddedMavenImpl extends BuildStageImpl<BuildStage> implements
-    MavenInvokerEquippedEmbeddedMaven {
+public class MavenInvokerEquippedEmbeddedMavenImpl
+    extends BuildStageImpl<BuildStage<WithoutTimeoutDaemonBuilder>, WithoutTimeoutDaemonBuilder>
+    implements MavenInvokerEquippedEmbeddedMaven {
 
     private InvocationRequest request;
     private Invoker invoker;
@@ -33,6 +35,11 @@ public class MavenInvokerEquippedEmbeddedMavenImpl extends BuildStageImpl<BuildS
     @Override
     protected StringBuffer getLogBuffer() {
         return null;
+    }
+
+    @Override
+    protected boolean isQuiet() {
+        return false;
     }
 
     @Override

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/AbstractOutputHandler.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/AbstractOutputHandler.java
@@ -1,0 +1,47 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.regex.Pattern;
+import org.apache.maven.shared.invoker.InvocationOutputHandler;
+import org.jboss.shrinkwrap.resolver.impl.maven.util.Validate;
+
+public abstract class AbstractOutputHandler implements InvocationOutputHandler {
+
+    private final StringBuffer logBuffer;
+    private Pattern expectedPattern;
+    private CountDownLatch countDownLatch;
+    private boolean quiet = false;
+
+    public AbstractOutputHandler(StringBuffer logBuffer, String expectedRegex, CountDownLatch countDownLatch) {
+        this.logBuffer = logBuffer;
+        if (expectedRegex != null) {
+            expectedPattern = Pattern.compile(expectedRegex);
+            this.countDownLatch = countDownLatch;
+        }
+    }
+
+    public AbstractOutputHandler(StringBuffer logBuffer) {
+        this.logBuffer = logBuffer;
+    }
+
+    @Override
+    public void consumeLine(String line) {
+        if (!quiet) {
+            printLine("-> " + line);
+        }
+        if (expectedPattern == null) {
+            logBuffer.append(line).append("\n");
+
+        } else if (countDownLatch != null && countDownLatch.getCount() > 0 && !Validate.isNullOrEmpty(line)) {
+            if (line.matches(expectedPattern.toString())) {
+                countDownLatch.countDown();
+            }
+        }
+    }
+
+    public void setQuiet(boolean quiet) {
+        this.quiet = quiet;
+    }
+
+    protected abstract void printLine(String line);
+}

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ConfigurationStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ConfigurationStageImpl.java
@@ -5,8 +5,8 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-
 import org.apache.maven.shared.invoker.InvokerLogger;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.WithTimeoutDaemonBuilder;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.pom.equipped.ConfigurationDistributionStage;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.pom.equipped.ConfigurationStage;
 import org.jboss.shrinkwrap.resolver.impl.maven.embedded.BuildStageImpl;
@@ -14,8 +14,9 @@ import org.jboss.shrinkwrap.resolver.impl.maven.embedded.BuildStageImpl;
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
-public abstract class ConfigurationStageImpl extends BuildStageImpl<ConfigurationStage> implements
-    ConfigurationDistributionStage {
+public abstract class ConfigurationStageImpl extends
+    BuildStageImpl<ConfigurationStage<ConfigurationDistributionStage, WithTimeoutDaemonBuilder>, WithTimeoutDaemonBuilder>
+    implements ConfigurationDistributionStage {
 
     private boolean skipTests = true;
 

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenImpl.java
@@ -19,7 +19,6 @@ package org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped;
 
 import java.io.File;
 import java.util.Properties;
-
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.DefaultInvoker;
 import org.apache.maven.shared.invoker.InvocationRequest;
@@ -32,14 +31,12 @@ import org.jboss.shrinkwrap.resolver.api.maven.embedded.pom.equipped.PomEquipped
 /**
  * @author <a href="mailto:mjobanek@gmail.com">Matous Jobanek</a>
  */
-public class PomEquippedEmbeddedMavenImpl extends ConfigurationStageImpl implements
-    PomEquippedEmbeddedMaven {
+public class PomEquippedEmbeddedMavenImpl extends ConfigurationStageImpl implements PomEquippedEmbeddedMaven {
 
     protected final InvocationRequest request = new DefaultInvocationRequest();
     protected Invoker invoker = new DefaultInvoker();
     private StringBuffer logBuffer = new StringBuffer("");
-    private ResolverErrorOutputHandler errorOutputHandler = new ResolverErrorOutputHandler(logBuffer);
-    private ResolverOutputHandler outputHandler = new ResolverOutputHandler(logBuffer);
+    private boolean quiet = false;
 
     protected PomEquippedEmbeddedMavenImpl(File pomFile) {
         Validate.notNull(pomFile, "Pom file can not be null!");
@@ -56,12 +53,6 @@ public class PomEquippedEmbeddedMavenImpl extends ConfigurationStageImpl impleme
         Properties properties = new Properties();
         properties.put("skipTests", "true");
         request.setProperties(properties);
-
-        invoker.setOutputHandler(outputHandler);
-        request.setOutputHandler(outputHandler);
-
-        invoker.setErrorHandler(errorOutputHandler);
-        request.setErrorHandler(errorOutputHandler);
     }
 
     @Override
@@ -85,8 +76,7 @@ public class PomEquippedEmbeddedMavenImpl extends ConfigurationStageImpl impleme
 
     @Override
     public ConfigurationDistributionStage setQuiet(boolean quiet) {
-        errorOutputHandler.setQuiet(quiet);
-        outputHandler.setQuiet(quiet);
+        this.quiet = quiet;
         return this;
     }
 
@@ -96,4 +86,8 @@ public class PomEquippedEmbeddedMavenImpl extends ConfigurationStageImpl impleme
         return this;
     }
 
+    @Override
+    protected boolean isQuiet() {
+        return quiet;
+    }
 }

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ResolverErrorOutputHandler.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ResolverErrorOutputHandler.java
@@ -1,28 +1,22 @@
 package org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped;
 
-import org.apache.maven.shared.invoker.InvocationOutputHandler;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
-public class ResolverErrorOutputHandler implements InvocationOutputHandler {
+public class ResolverErrorOutputHandler extends AbstractOutputHandler {
 
-    private final StringBuffer logBuffer;
-    private boolean quiet = false;
+    public ResolverErrorOutputHandler(StringBuffer logBuffer, String expectedRegex, CountDownLatch countDownLatch) {
+        super(logBuffer, expectedRegex, countDownLatch);
+    }
 
     public ResolverErrorOutputHandler(StringBuffer logBuffer) {
-        this.logBuffer = logBuffer;
+        super(logBuffer);
     }
 
     @Override
-    public void consumeLine(String line) {
-        if (!quiet) {
-            System.err.println("-> " + line);
-        }
-        logBuffer.append(line).append("\n");
-    }
-
-    public void setQuiet(boolean quiet){
-        this.quiet = quiet;
+    protected void printLine(String line) {
+        System.err.println(line);
     }
 }

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ResolverOutputHandler.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ResolverOutputHandler.java
@@ -1,28 +1,22 @@
 package org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped;
 
-import org.apache.maven.shared.invoker.InvocationOutputHandler;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
  */
-public class ResolverOutputHandler implements InvocationOutputHandler {
+public class ResolverOutputHandler extends AbstractOutputHandler {
 
-    private final StringBuffer logBuffer;
-    private boolean quiet = false;
+    public ResolverOutputHandler(StringBuffer logBuffer, String expectedRegex, CountDownLatch countDownLatch) {
+        super(logBuffer, expectedRegex, countDownLatch);
+    }
 
     public ResolverOutputHandler(StringBuffer logBuffer) {
-        this.logBuffer = logBuffer;
+        super(logBuffer);
     }
 
     @Override
-    public void consumeLine(String line) {
-        if (!quiet) {
-            System.out.println("-> " + line);
-        }
-        logBuffer.append(line).append("\n");
-    }
-
-    public void setQuiet(boolean quiet) {
-        this.quiet = quiet;
+    protected void printLine(String line) {
+        System.out.println(line);
     }
 }

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/ConfigurationStageTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/ConfigurationStageTestCase.java
@@ -75,8 +75,6 @@ public class ConfigurationStageTestCase {
         assertEquals(mavenOpts, invocationRequest.getMavenOpts());
         File jarSamplePom = new File(pathToJarSamplePom);
         assertEquals(jarSamplePom.getAbsoluteFile(), invocationRequest.getPomFile());
-        assertNotNull(invocationRequest.getErrorHandler(null));
-        assertNotNull(invocationRequest.getOutputHandler(null));
         assertEquals(Arrays.asList(profiles), invocationRequest.getProfiles());
         assertEquals(Arrays.asList(projects), invocationRequest.getProjects());
         assertEquals(resumeFrom, invocationRequest.getResumeFrom());

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase.java
@@ -34,7 +34,7 @@ public class InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase {
         Invoker invoker = new DefaultInvoker();
 
         request.setPomFile(new File(pathToJarSamplePom));
-        request.setGoals(Arrays.asList(new String[] { "clean", "verify" }));
+        request.setGoals(Arrays.asList(new String[] { "clean", "package" }));
 
         request.setProperties(getPropertiesWithSkipTests());
 
@@ -43,7 +43,7 @@ public class InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase {
             .useAsDaemon()
             .build();
 
-        Thread.sleep(1000);
+        Thread.sleep(900);
         Assertions.assertThat(outContent.toString()).contains("Embedded Maven build started");
         Assertions.assertThat(outContent.toString()).doesNotContain("Embedded Maven build stopped");
     }

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase.java
@@ -1,0 +1,55 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded.invoker.equipped;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.concurrent.TimeoutException;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.Invoker;
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.getPropertiesWithSkipTests;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToJarSamplePom;
+
+public class InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+
+    @Before
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @Test
+    public void testWhenDaemonIsUsedEndOfTheBuildIsNotReached() throws InterruptedException, TimeoutException {
+
+        final InvocationRequest request = new DefaultInvocationRequest();
+        Invoker invoker = new DefaultInvoker();
+
+        request.setPomFile(new File(pathToJarSamplePom));
+        request.setGoals(Arrays.asList(new String[] { "clean", "verify" }));
+
+        request.setProperties(getPropertiesWithSkipTests());
+
+        EmbeddedMaven
+            .withMavenInvokerSet(request, invoker)
+            .useAsDaemon()
+            .build();
+
+        Thread.sleep(1000);
+        Assertions.assertThat(outContent.toString()).contains("Embedded Maven build started");
+        Assertions.assertThat(outContent.toString()).doesNotContain("Embedded Maven build stopped");
+    }
+
+    @After
+    public void cleanUpStreams() {
+        System.setOut(System.out);
+    }
+}

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase.java
@@ -4,11 +4,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.DefaultInvoker;
 import org.apache.maven.shared.invoker.InvocationRequest;
 import org.apache.maven.shared.invoker.Invoker;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuild;
 import org.junit.After;
@@ -38,22 +41,25 @@ public class InvokerEquippedEmbeddedMavenRunningAsDaemonTestCase {
 
         request.setProperties(getPropertiesWithSkipTests());
 
-        DaemonBuild daemonBuild = EmbeddedMaven
+        final DaemonBuild daemonBuild = EmbeddedMaven
             .withMavenInvokerSet(request, invoker)
             .useAsDaemon()
             .build();
 
-        Thread.sleep(900);
-        Assertions.assertThat(outContent.toString()).contains("Embedded Maven build started");
+        Awaitility.await("Wait till maven build is started").atMost(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return outContent.toString().contains("Embedded Maven build started");
+            }
+        });
         Assertions.assertThat(outContent.toString()).doesNotContain("Embedded Maven build stopped");
 
-        int timeout = 0;
-        while (daemonBuild.isAlive() && timeout <= 20) {
-            Thread.sleep(500);
-        }
-        Assertions.assertThat(timeout)
-            .as("The build should have finish (built project should not be null) within 10 seconds")
-            .isLessThanOrEqualTo(10);
+        Awaitility.await("Wait till project is not be null").atMost(20, TimeUnit.SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return daemonBuild.getBuiltProject() != null;
+            }
+        });
 
         Assertions.assertThat(daemonBuild.isAlive()).isFalse();
     }

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningAsDaemonTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningAsDaemonTestCase.java
@@ -1,0 +1,67 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToJarSamplePom;
+
+public class PomEquippedEmbeddedMavenRunningAsDaemonTestCase {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+
+    @Test
+    public void testDaemonShouldWaitForBuildSuccess() throws TimeoutException {
+        EmbeddedMaven
+            .forProject(pathToJarSamplePom)
+            .setGoals("package")
+            .useAsDaemon()
+            .withWaitUntilOutputLineMathes(".*BUILD SUCCESS.*")
+            .build();
+    }
+
+    @Test
+    public void testDaemonWithoutWaitShouldNotReachTheEndOfTheBuild() throws TimeoutException, InterruptedException {
+        System.setOut(new PrintStream(outContent));
+
+        EmbeddedMaven
+            .forProject(pathToJarSamplePom)
+            .setGoals("clean", "verify")
+            .useAsDaemon()
+            .build();
+
+        Thread.sleep(1000);
+        Assertions.assertThat(outContent.toString()).contains("Embedded Maven build started");
+        Assertions.assertThat(outContent.toString()).doesNotContain("Embedded Maven build stopped");
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testDaemonShouldThrowTimeoutExceptionBecauseOfLowTimeout() throws TimeoutException {
+        EmbeddedMaven
+            .forProject(pathToJarSamplePom)
+            .setGoals("clean", "verify")
+            .useAsDaemon()
+            .withWaitUntilOutputLineMathes(".*BUILD SUCCESS.*", 1, TimeUnit.SECONDS)
+            .build();
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testDaemonShouldThrowTimeoutExceptionBecauseOfWrongRegex() throws TimeoutException {
+        EmbeddedMaven
+            .forProject(pathToJarSamplePom)
+            .setGoals("package")
+            .useAsDaemon()
+            .withWaitUntilOutputLineMathes("blabla", 5, TimeUnit.SECONDS)
+            .build();
+    }
+
+    @After
+    public void cleanUpStreams() {
+        System.setOut(System.out);
+    }
+}

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningAsDaemonTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningAsDaemonTestCase.java
@@ -6,30 +6,45 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuild;
 import org.junit.After;
 import org.junit.Test;
 
 import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToJarSamplePom;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.verifyJarSampleContainsOnlyOneJar;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.verifyJarSampleSimpleBuild;
 
 public class PomEquippedEmbeddedMavenRunningAsDaemonTestCase {
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
 
     @Test
-    public void testDaemonShouldWaitForBuildSuccess() throws TimeoutException {
-        EmbeddedMaven
+    public void testDaemonShouldWaitForBuildSuccess() throws TimeoutException, InterruptedException {
+        DaemonBuild daemonBuild = EmbeddedMaven
             .forProject(pathToJarSamplePom)
             .setGoals("package")
             .useAsDaemon()
             .withWaitUntilOutputLineMathes(".*BUILD SUCCESS.*")
             .build();
+
+        int timeout = 0;
+        while (daemonBuild.isAlive() && timeout <= 20) {
+            Thread.sleep(500);
+        }
+        Assertions.assertThat(timeout)
+            .as("The build should have finish (not to be alive) within 10 seconds")
+            .isLessThanOrEqualTo(10);
+
+        Assertions.assertThat(daemonBuild.getBuiltProject()).isNotNull();
+        verifyJarSampleSimpleBuild(daemonBuild.getBuiltProject());
+        verifyJarSampleContainsOnlyOneJar(daemonBuild.getBuiltProject());
     }
 
     @Test
-    public void testDaemonWithoutWaitShouldNotReachTheEndOfTheBuild() throws TimeoutException, InterruptedException {
+    public void testDaemonWithoutWaitShouldNotReachTheEndOfTheBuild() throws InterruptedException {
         System.setOut(new PrintStream(outContent));
 
-        EmbeddedMaven
+        DaemonBuild daemonBuild = EmbeddedMaven
             .forProject(pathToJarSamplePom)
             .setGoals("clean", "package")
             .useAsDaemon()
@@ -38,6 +53,20 @@ public class PomEquippedEmbeddedMavenRunningAsDaemonTestCase {
         Thread.sleep(900);
         Assertions.assertThat(outContent.toString()).contains("Embedded Maven build started");
         Assertions.assertThat(outContent.toString()).doesNotContain("Embedded Maven build stopped");
+        Assertions.assertThat(daemonBuild.isAlive()).isTrue();
+        Assertions.assertThat(daemonBuild.getBuiltProject()).isNull();
+
+        int timeout = 0;
+        while (daemonBuild.isAlive() && timeout <= 20) {
+            Thread.sleep(500);
+        }
+        Assertions.assertThat(timeout)
+            .as("The build should have finish (built project should not be null) within 10 seconds")
+            .isLessThanOrEqualTo(10);
+
+        Assertions.assertThat(daemonBuild.isAlive()).isFalse();
+        verifyJarSampleSimpleBuild(daemonBuild.getBuiltProject());
+        verifyJarSampleContainsOnlyOneJar(daemonBuild.getBuiltProject());
     }
 
     @Test(expected = TimeoutException.class)

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningAsDaemonTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningAsDaemonTestCase.java
@@ -31,11 +31,11 @@ public class PomEquippedEmbeddedMavenRunningAsDaemonTestCase {
 
         EmbeddedMaven
             .forProject(pathToJarSamplePom)
-            .setGoals("clean", "verify")
+            .setGoals("clean", "package")
             .useAsDaemon()
             .build();
 
-        Thread.sleep(1000);
+        Thread.sleep(900);
         Assertions.assertThat(outContent.toString()).contains("Embedded Maven build started");
         Assertions.assertThat(outContent.toString()).doesNotContain("Embedded Maven build stopped");
     }
@@ -44,7 +44,7 @@ public class PomEquippedEmbeddedMavenRunningAsDaemonTestCase {
     public void testDaemonShouldThrowTimeoutExceptionBecauseOfLowTimeout() throws TimeoutException {
         EmbeddedMaven
             .forProject(pathToJarSamplePom)
-            .setGoals("clean", "verify")
+            .setGoals("clean", "package")
             .useAsDaemon()
             .withWaitUntilOutputLineMathes(".*BUILD SUCCESS.*", 1, TimeUnit.SECONDS)
             .build();


### PR DESCRIPTION
It is possible to stop the execution and wait till some line matches a regex. Useful for cases when maven build triggers some server or other application (eg. using mvn spring-boot:run)

use-case when I need this functionality is when I run che-starter using mvn command:
~~~java
EmbeddedMaven
    .forProject(cheStarterDir.getAbsolutePath() + "/pom.xml")
    .useMaven3Version("3.5.0")
    .setGoals("spring-boot:run")
    .useAsDaemon()
    .withWaitUntilOutputLineMathes(".*Started Application in.*", 30, TimeUnit.SECONDS)
    .build();
~~~