### PR TITLE
EmbeddedMaven - default version

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -508,7 +508,7 @@ In cases when there is no Maven binaries installed on the machine or when anothe
 EmbeddedMaven.forProject("path/to/pom.xml").useMaven3Version(String version)
 ....
 [%hardbreaks]
-where the desired version is expected (eg: `useMaven3Version("3.3.9")`). This version is downloaded from Apache web pages and the downloaded zip is cached in a directory `$HOME/.arquillian/resolver/maven/` to not download it over and over again. Zip file is extracted in `${project.directory}/target/resolver-maven/${file_md5hash}` and the path to the extracted binaries is set as Maven home applicable for the build.
+where the desired version is expected (eg: `useMaven3Version("3.3.3")`). This version is downloaded from Apache web pages and the downloaded zip is cached in a directory `$HOME/.arquillian/resolver/maven/` to not download it over and over again. Zip file is extracted in `${project.directory}/target/resolver-maven/${file_md5hash}` and the path to the extracted binaries is set as Maven home applicable for the build.
 There are three more methods for setting Maven binaries that should be used for the build.
 [source,java]
 ....
@@ -523,13 +523,21 @@ EmbeddedMaven.forProject("path/to/pom.xml").useInstallation(File mavenHome)
 ....
 [%hardbreaks]
 uses Maven installation located on the given path.
-Last method:
+And the method:
+[source,java]
+....
+EmbeddedMaven.forProject("path/to/pom.xml").useLocalInstallation()
+....
+uses local Maven installation that is available on your PATH.
+
+==== Default Maven binary
+
+If no version, distribution nor installation is specified, then EmbeddedMaven uses the default version, which is currently `3.3.9`.
+The very same result (downloading & using default Maven binary version) you can achieve by using method:
 [source,java]
 ....
 EmbeddedMaven.forProject("path/to/pom.xml").useDefaultDistribution()
 ....
-basically does nothing. It just says that the default Maven installation that is on your `PATH` should be used. It is same as you wouldn't use any of these methods.
-
 
 === Explanation of additional features:
 

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/DistributionStage.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/DistributionStage.java
@@ -27,6 +27,8 @@ import org.jboss.shrinkwrap.resolver.api.maven.embedded.daemon.DaemonBuildTrigge
 public interface DistributionStage<NEXT_STEP extends BuildStage<DAEMON_TRIGGER_TYPE>, DAEMON_TRIGGER_TYPE extends DaemonBuildTrigger>
     extends BuildStage<DAEMON_TRIGGER_TYPE> {
 
+    String DEFAULT_MAVEN_VERSION = "3.3.9";
+
     /**
      * Configures EmbeddedMaven to build project with Maven 3 of given version. If the zip file is not cached in directory
      * $HOME/.arquillian/resolver/maven/ then it will be downloaded from Apache web pages and zip file cached.
@@ -56,10 +58,16 @@ public interface DistributionStage<NEXT_STEP extends BuildStage<DAEMON_TRIGGER_T
     NEXT_STEP useInstallation(File mavenHome);
 
     /**
-     * Use default Maven distribution that is on your path.
+     * Use default Maven distribution with version {@link DEFAULT_MAVEN_VERSION}.
      *
      * @return Modified EmbeddedMaven instance
      */
     NEXT_STEP  useDefaultDistribution();
 
+    /**
+     * Use local Maven installation that is available on your PATH.
+     *
+     * @return Modified EmbeddedMaven instance
+     */
+    NEXT_STEP useLocalInstallation();
 }

--- a/maven/impl-maven-embedded/pom.xml
+++ b/maven/impl-maven-embedded/pom.xml
@@ -97,6 +97,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                    <systemProperties>
+                        <property>
+                            <name>version.org.apache.maven.dependency</name>
+                            <value>${version.org.apache.maven}</value>
+                        </property>
+                    </systemProperties>
                 </configuration>
             </plugin>
         </plugins>

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildStageImpl.java
@@ -38,6 +38,9 @@ public abstract class BuildStageImpl<NEXT_STEP extends BuildStage<DAEMON_TRIGGER
     }
 
     private BuildTrigger createBuildTrigger(){
+        if (getSetMavenInstallation() == null && !shouldUseLocalInstallation()){
+            useMaven3Version(DEFAULT_MAVEN_VERSION);
+        }
         return new BuildTrigger(
             getSetMavenInstallation(),
             getInvocationRequest(),

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DistributionStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DistributionStageImpl.java
@@ -26,8 +26,15 @@ public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage<DAEMON_
 
     private static final String MAVEN_3_BASE_URL =
             "https://archive.apache.org/dist/maven/maven-3/%version%/binaries/apache-maven-%version%-bin.tar.gz";
-    private File setMavenInstalation = null;
-    private String mavenTargetDir = "target" + File.separator + "resolver-maven";
+    public static final String MAVEN_TARGET_DIR = "target" + File.separator + "resolver-maven";
+    public static final String MAVEN_CACHE_DIR =
+        System.getProperty("user.home") + File.separator
+            + ".arquillian" + File.separator
+            + "resolver" + File.separator
+            + "maven";
+
+    private File setMavenInstallation = null;
+    private boolean useLocalInstallation = false;
     private Logger log = Logger.getLogger(DistributionStage.class.getName());
 
     @Override
@@ -63,7 +70,7 @@ public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage<DAEMON_
 
     private File checkIfItIsAlreadyExtracted(final String downloadedZipMd5hash) {
 
-        File[] dirs = new File(mavenTargetDir).listFiles(new FileFilter() {
+        File[] dirs = new File(MAVEN_TARGET_DIR).listFiles(new FileFilter() {
 
             @Override
             public boolean accept(File file) {
@@ -96,7 +103,7 @@ public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage<DAEMON_
 
     private File extract(File downloaded, String downloadedZipMd5hash) {
 
-            File toExtract = new File(mavenTargetDir + File.separator + downloadedZipMd5hash);
+        File toExtract = new File(MAVEN_TARGET_DIR + File.separator + downloadedZipMd5hash);
             toExtract.mkdirs();
             String downloadedPath = downloaded.getAbsolutePath();
 
@@ -195,14 +202,10 @@ public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage<DAEMON_
     private File prepareMavenDir(boolean useCache) {
         String dirPath;
         if (useCache) {
-            dirPath =
-                    System.getProperty("user.home") + File.separator
-                            + ".arquillian" + File.separator
-                            + "resolver" + File.separator
-                            + "maven";
+            dirPath = MAVEN_CACHE_DIR;
         } else {
             dirPath =
-                    mavenTargetDir + File.separator
+                MAVEN_TARGET_DIR + File.separator
                             + "downloaded" + File.separator;
         }
 
@@ -215,17 +218,28 @@ public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage<DAEMON_
 
     @Override
     public NEXT_STEP useInstallation(File mavenHome) {
-        this.setMavenInstalation = mavenHome;
+        this.setMavenInstallation = mavenHome;
         return returnNextStepType();
     }
 
     @Override
     public NEXT_STEP useDefaultDistribution() {
+        useMaven3Version(DEFAULT_MAVEN_VERSION);
+        return returnNextStepType();
+    }
+
+    @Override
+    public NEXT_STEP useLocalInstallation() {
+        useLocalInstallation = true;
         return returnNextStepType();
     }
 
     protected File getSetMavenInstallation() {
-        return setMavenInstalation;
+        return setMavenInstallation;
+    }
+
+    protected boolean shouldUseLocalInstallation() {
+        return useLocalInstallation;
     }
 
     protected abstract NEXT_STEP returnNextStepType();

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildOutputTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/BuildOutputTestCase.java
@@ -30,7 +30,7 @@ public class BuildOutputTestCase {
         EmbeddedMaven
             .forProject(pathToJarSamplePom)
             .setGoals("clean", "verify")
-            .useDefaultDistribution()
+            .useLocalInstallation()
             .build();
 
         verifyStatuses();
@@ -43,7 +43,7 @@ public class BuildOutputTestCase {
             .forProject(pathToJarSamplePom)
             .setGoals("clean", "verify")
             .setQuiet()
-            .useDefaultDistribution()
+            .useLocalInstallation()
             .build();
 
         verifyStatuses();

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DefaultMavenVersionTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DefaultMavenVersionTestCase.java
@@ -1,0 +1,16 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.DistributionStage;
+import org.junit.Assume;
+import org.junit.Test;
+
+public class DefaultMavenVersionTestCase {
+
+    @Test
+    public void default_version_should_be_same_as_dependency_version() {
+        String depVersion = System.getProperty("version.org.apache.maven.dependency");
+        Assume.assumeNotNull(depVersion);
+        Assertions.assertThat(DistributionStage.DEFAULT_MAVEN_VERSION).isEqualTo(depVersion);
+    }
+}

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenForJarSampleTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenForJarSampleTestCase.java
@@ -36,7 +36,7 @@ public class InvokerEquippedEmbeddedMavenForJarSampleTestCase {
 
         BuiltProject builtProject = EmbeddedMaven
             .withMavenInvokerSet(request, invoker)
-            .useDefaultDistribution()
+            .useLocalInstallation()
             .build();
 
         verifyJarSampleSimpleBuild(builtProject);
@@ -56,7 +56,7 @@ public class InvokerEquippedEmbeddedMavenForJarSampleTestCase {
 
         BuiltProject builtProject = EmbeddedMaven
             .withMavenInvokerSet(request, invoker)
-            .useDefaultDistribution()
+            .useLocalInstallation()
             .build();
 
 

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenForJarSampleTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenForJarSampleTestCase.java
@@ -19,7 +19,7 @@ public class PomEquippedEmbeddedMavenForJarSampleTestCase {
         BuiltProject builtProject = EmbeddedMaven
             .forProject(pathToJarSamplePom)
             .setGoals("clean", "verify")
-            .useDefaultDistribution()
+            .useLocalInstallation()
             .build();
 
         verifyJarSampleSimpleBuild(builtProject);


### PR DESCRIPTION
 By default, it uses hard-coded Maven binary version(corresponding to Maven dependency) - which is `3.3.9`.
Added another method `useLocalInstallation` to set that the binary available on PATH should be used.