### PR TITLE
Introduces functionality to set an alternate POM file in embedded maven.

### DIFF
--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/pom/equipped/ConfigurationStage.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/pom/equipped/ConfigurationStage.java
@@ -353,4 +353,12 @@ public interface ConfigurationStage<DIST_OR_CONFIG extends ConfigurationStage, D
       * @return Modified EmbeddedMaven instance
       */
      DIST_OR_CONFIG setQuiet();
+
+    /**
+     * Sets an alternate POM file. Equivalent of -f or --file
+     *
+     * @param pomFile the alternate POM file (or directory with pom.xml)
+     * @return Modified instance of EmbeddedMaven
+     */
+    DIST_OR_CONFIG setAlternatePomFile(String pomFile);
 }

--- a/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/pom/equipped/ConfigurationStage.java
+++ b/maven/api-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/embedded/pom/equipped/ConfigurationStage.java
@@ -357,7 +357,7 @@ public interface ConfigurationStage<DIST_OR_CONFIG extends ConfigurationStage, D
     /**
      * Sets an alternate POM file. Equivalent of -f or --file
      *
-     * @param pomFile the alternate POM file (or directory with pom.xml)
+     * @param pomFile the alternate POM file (or directory with pom.xml), may be null to use the already processed pom.
      * @return Modified instance of EmbeddedMaven
      */
     DIST_OR_CONFIG setAlternatePomFile(String pomFile);

--- a/maven/impl-maven-embedded/src/it/cube-gradle-sample/gradle-sample/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningWithAlternateTestCase.java
+++ b/maven/impl-maven-embedded/src/it/cube-gradle-sample/gradle-sample/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningWithAlternateTestCase.java
@@ -1,0 +1,31 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped;
+
+import java.io.File;
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
+import org.junit.Test;
+
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToJarSamplePom;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToWarSamplePom;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.verifyWarSampleWithSources;
+
+public class PomEquippedEmbeddedMavenRunningWithAlternateTestCase {
+
+    @Test
+    public void testWarSampleBuildUsingAlternatePomFile() {
+        BuiltProject builtProject = EmbeddedMaven
+            .forProject(pathToJarSamplePom)
+            .setAlternatePomFile(pathToWarSamplePom)
+            .setGoals("clean", "package", "source:jar")
+            .useDefaultDistribution()
+            .build();
+
+        File warSamplePom = new File(pathToWarSamplePom);
+        File jarSamplePom = new File(pathToJarSamplePom);
+
+        Assertions.assertThat(builtProject.getModel().getPomFile()).isEqualTo(warSamplePom.getAbsoluteFile());
+        Assertions.assertThat(builtProject.getModel().getPomFile()).isNotEqualTo(jarSamplePom.getAbsoluteFile());
+        verifyWarSampleWithSources(builtProject);
+    }
+}

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ConfigurationStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ConfigurationStageImpl.java
@@ -80,6 +80,7 @@ public abstract class ConfigurationStageImpl extends
 
     @Override
     public ConfigurationDistributionStage setWorkingDirectory(File workingDirectory) {
+        getInvocationRequest().setBaseDirectory(workingDirectory);
         getInvoker().setWorkingDirectory(workingDirectory);
         return this;
     }

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ConfigurationStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ConfigurationStageImpl.java
@@ -85,7 +85,7 @@ public abstract class ConfigurationStageImpl extends
     }
 
     @Override
-    public ConfigurationDistributionStage setInputStream(InputStream inputStream){
+    public ConfigurationDistributionStage setInputStream(InputStream inputStream) {
         getInvoker().setInputStream(inputStream);
         getInvocationRequest().setInputStream(inputStream);
         return this;
@@ -105,13 +105,13 @@ public abstract class ConfigurationStageImpl extends
     }
 
     @Override
-    public ConfigurationDistributionStage addProperty(String key, String value){
+    public ConfigurationDistributionStage addProperty(String key, String value) {
         getInvocationRequest().getProperties().put(key, value);
         return this;
     }
 
     @Override
-    public ConfigurationDistributionStage skipTests(boolean skipTests){
+    public ConfigurationDistributionStage skipTests(boolean skipTests) {
         this.skipTests = skipTests;
         getInvocationRequest().getProperties().put("skipTests", String.valueOf(skipTests));
         return this;
@@ -240,6 +240,18 @@ public abstract class ConfigurationStageImpl extends
     @Override
     public ConfigurationDistributionStage setResumeFrom(String resumeFrom) {
         getInvocationRequest().setResumeFrom(resumeFrom);
+        return this;
+    }
+
+    @Override
+    public ConfigurationDistributionStage setAlternatePomFile(String pomFile) {
+        if(pomFile != null) {
+            File pom = new File(pomFile).getAbsoluteFile();
+            if (pom.isDirectory()) {
+                pom = new File(pom, "pom.xml");
+            }
+            getInvocationRequest().setPomFile(pom);
+        }
         return this;
     }
 }

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ConfigurationStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/ConfigurationStageImpl.java
@@ -243,16 +243,4 @@ public abstract class ConfigurationStageImpl extends
         getInvocationRequest().setResumeFrom(resumeFrom);
         return this;
     }
-
-    @Override
-    public ConfigurationDistributionStage setAlternatePomFile(String pomFile) {
-        if(pomFile != null) {
-            File pom = new File(pomFile).getAbsoluteFile();
-            if (pom.isDirectory()) {
-                pom = new File(pom, "pom.xml");
-            }
-            getInvocationRequest().setPomFile(pom);
-        }
-        return this;
-    }
 }

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenImpl.java
@@ -90,4 +90,16 @@ public class PomEquippedEmbeddedMavenImpl extends ConfigurationStageImpl impleme
     protected boolean isQuiet() {
         return quiet;
     }
+
+    @Override
+    public ConfigurationDistributionStage setAlternatePomFile(String pomFile) {
+        if(pomFile != null) {
+            File pom = new File(pomFile).getAbsoluteFile();
+            if (pom.isDirectory()) {
+                pom = new File(pom, "pom.xml");
+            }
+            getInvocationRequest().setPomFile(pom);
+        }
+        return this;
+    }
 }

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/ConfigurationStageTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/ConfigurationStageTestCase.java
@@ -18,6 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToJarSamplePom;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToMultiModulePom;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
@@ -74,8 +75,8 @@ public class ConfigurationStageTestCase {
         softly.assertThat(invocationRequest.getJavaHome()).isEqualTo(javaHome);
         softly.assertThat(invocationRequest.getLocalRepositoryDirectory(null)).isEqualTo(localRepositoryDirectory);
         softly.assertThat(invocationRequest.getMavenOpts()).isEqualTo(mavenOpts);
-        File jarSamplePom = new File(pathToJarSamplePom);
-        softly.assertThat(invocationRequest.getPomFile()).isEqualTo(jarSamplePom.getAbsoluteFile());
+        File multiModuleSamplePom = new File(pathToMultiModulePom);
+        softly.assertThat(invocationRequest.getPomFile()).isEqualTo(multiModuleSamplePom.getAbsoluteFile());
         softly.assertThat(invocationRequest.getProfiles()).containsExactly(profiles);
         softly.assertThat(invocationRequest.getProjects()).containsExactly(projects);
         softly.assertThat(invocationRequest.getResumeFrom()).isEqualTo(resumeFrom);
@@ -155,6 +156,7 @@ public class ConfigurationStageTestCase {
                 .setRecursive(true)
                 .setUserSettingsFile(userSettingFile)
                 .setWorkingDirectory(workingDirectory)
+                .setAlternatePomFile(pathToMultiModulePom)
                 .setBuilder(builderId);
 
         return (ConfigurationStageImpl) configurationStage;

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/ConfigurationStageTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/ConfigurationStageTestCase.java
@@ -18,7 +18,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToJarSamplePom;
-import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToMultiModulePom;
 
 /**
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
@@ -75,8 +74,8 @@ public class ConfigurationStageTestCase {
         softly.assertThat(invocationRequest.getJavaHome()).isEqualTo(javaHome);
         softly.assertThat(invocationRequest.getLocalRepositoryDirectory(null)).isEqualTo(localRepositoryDirectory);
         softly.assertThat(invocationRequest.getMavenOpts()).isEqualTo(mavenOpts);
-        File multiModuleSamplePom = new File(pathToMultiModulePom);
-        softly.assertThat(invocationRequest.getPomFile()).isEqualTo(multiModuleSamplePom.getAbsoluteFile());
+        File jarSamplePom = new File(pathToJarSamplePom);
+        softly.assertThat(invocationRequest.getPomFile()).isEqualTo(jarSamplePom.getAbsoluteFile());
         softly.assertThat(invocationRequest.getProfiles()).containsExactly(profiles);
         softly.assertThat(invocationRequest.getProjects()).containsExactly(projects);
         softly.assertThat(invocationRequest.getResumeFrom()).isEqualTo(resumeFrom);
@@ -156,7 +155,6 @@ public class ConfigurationStageTestCase {
                 .setRecursive(true)
                 .setUserSettingsFile(userSettingFile)
                 .setWorkingDirectory(workingDirectory)
-                .setAlternatePomFile(pathToMultiModulePom)
                 .setBuilder(builderId);
 
         return (ConfigurationStageImpl) configurationStage;

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningWithAlternateTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenRunningWithAlternateTestCase.java
@@ -1,0 +1,28 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded.pom.equipped;
+
+import java.io.File;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToJarSamplePom;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToWarSamplePom;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.verifyWarSampleWithSources;
+
+public class PomEquippedEmbeddedMavenRunningWithAlternateTestCase {
+
+    @Test
+    public void testWarSampleBuildUsingAlternatePomFile() {
+        BuiltProject builtProject = EmbeddedMaven
+            .forProject(pathToJarSamplePom)
+            .setAlternatePomFile(pathToWarSamplePom)
+            .setGoals("clean", "package", "source:jar")
+            .useDefaultDistribution()
+            .build();
+
+        assertThat(builtProject.getModel().getPomFile()).isEqualTo(new File(pathToWarSamplePom).getAbsoluteFile());
+        assertThat(builtProject.getModel().getPomFile()).isNotEqualTo(new File(pathToJarSamplePom).getAbsoluteFile());
+        verifyWarSampleWithSources(builtProject);
+    }
+}


### PR DESCRIPTION
Sometimes it is required to use a POM file different from the parent pom file or a pom file in another modules for executing Maven goals. 

A feature equivalent to setting "-f or --file" parameter from CLI in embedded maven was missing.

This PR resolves this by providing a means of resetting the pom.xml file.


