### PR TITLE
SHRINKRES-281 Format processor for java.nio.file.Path

### DIFF
--- a/maven/impl-maven/src/main/resources/META-INF/services/org.jboss.shrinkwrap.resolver.spi.format.FormatProcessor
+++ b/maven/impl-maven/src/main/resources/META-INF/services/org.jboss.shrinkwrap.resolver.spi.format.FormatProcessor
@@ -1,5 +1,6 @@
 org.jboss.shrinkwrap.resolver.spi.format.FileFormatProcessor
 org.jboss.shrinkwrap.resolver.spi.format.URLFormatProcessor
 org.jboss.shrinkwrap.resolver.spi.format.InputStreamFormatProcessor
+org.jboss.shrinkwrap.resolver.spi.format.PathFormatProcessor
 org.jboss.shrinkwrap.resolver.impl.maven.format.MavenResolvedArtifactProcessor
 org.jboss.shrinkwrap.resolver.impl.maven.format.MavenCoordinateProcessor

--- a/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/format/FileFormatProcessor.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/format/FileFormatProcessor.java
@@ -36,9 +36,8 @@ public enum FileFormatProcessor implements FormatProcessor {
 
     @Override
     public File process(ResolvedArtifact artifact, Class returnType) throws IllegalArgumentException {
-        if (returnType.getClass() == null || File.class.equals(returnType.getClass())) {
-            throw new IllegalArgumentException("File processor must be called to return File, not "
-                    + (returnType == null ? "null" : returnType.getClass()));
+        if (returnType != File.class) {
+            throw new IllegalArgumentException("File processor must be called to return File, not " + returnType);
         }
         if (artifact == null) {
             throw new IllegalArgumentException("Resolution artifact must be specified");

--- a/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/format/InputStreamFormatProcessor.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/format/InputStreamFormatProcessor.java
@@ -43,9 +43,8 @@ public enum InputStreamFormatProcessor implements FormatProcessor {
     @Override
     public InputStream process(final ResolvedArtifact artifact, final Class returnType)
             throws IllegalArgumentException {
-        if (returnType.getClass() == null || InputStream.class.equals(returnType.getClass())) {
-            throw new IllegalArgumentException("InputStream processor must be called to return InputStream, not "
-                    + (returnType == null ? "null" : returnType.getClass()));
+        if (returnType != InputStream.class) {
+            throw new IllegalArgumentException("InputStream processor must be called to return InputStream, not " + returnType);
         }
         if (artifact == null) {
             throw new IllegalArgumentException("Resolution artifact must be specified");

--- a/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/format/PathFormatProcessor.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/format/PathFormatProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.shrinkwrap.resolver.spi.format;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.jboss.shrinkwrap.resolver.api.ResolvedArtifact;
+
+/**
+ * {@link FormatProcessor} implementation to return a {@link Path} from the provided {@link ResolvedArtifact} argument.
+ *
+ * Implementation note: This format processor does not use type parameters to be able to process any type inherited from
+ * {@link ResolvedArtifact}.
+ *
+ * @author Gunnar Morling
+ */
+@SuppressWarnings("rawtypes")
+public enum PathFormatProcessor implements FormatProcessor {
+
+    INSTANCE;
+
+    @Override
+    public boolean handles(Class resolvedTypeClass) {
+        return FileFormatProcessor.INSTANCE.handles(resolvedTypeClass);
+    }
+
+    @Override
+    public boolean returns(Class returnTypeClass) {
+        return Path.class.equals(returnTypeClass);
+    }
+
+    @Override
+    public Path process(ResolvedArtifact input, Class returnType) throws IllegalArgumentException {
+        if (returnType != Path.class) {
+            throw new IllegalArgumentException("Path processor must be called to return Path, not " + returnType);
+        }
+
+        return FileFormatProcessor.INSTANCE.process( input, File.class ).toPath();
+    }
+}

--- a/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/format/URLFormatProcessor.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/resolver/spi/format/URLFormatProcessor.java
@@ -39,9 +39,8 @@ public enum URLFormatProcessor implements FormatProcessor {
 
     @Override
     public URL process(ResolvedArtifact artifact, Class returnType) throws IllegalArgumentException {
-        if (returnType.getClass() == null || URL.class.equals(returnType.getClass())) {
-            throw new IllegalArgumentException("URL processor must be called to return URL, not "
-                    + (returnType == null ? "null" : returnType.getClass()));
+        if (returnType != URL.class) {
+            throw new IllegalArgumentException("URL processor must be called to return URL, not " + returnType);
         }
         if (artifact == null) {
             throw new IllegalArgumentException("Resolution artifact must be specified");


### PR DESCRIPTION
https://issues.jboss.org/browse/SHRINKRES-281

Hi, I thought that'd be a good addition in the age of NIO :)

I've tested it with my own project, but I wasn't sure where to add a test in ShrinkWrap itself. Happy to add one if you can give me some directions. Also I followed the example of the existing processors and registered the new one in the services file in the _impl-maven_ module. Is anything else needed to make it work for Gradle, too?