### PR TITLE
fix: Improved logic for extraction

### DIFF
--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DistributionStageImpl.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/DistributionStageImpl.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.logging.Logger;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.arquillian.spacelift.Spacelift;
@@ -52,7 +53,7 @@ public abstract class DistributionStageImpl<NEXT_STEP extends BuildStage<DAEMON_
             String downloadedZipMd5hash = getMd5hash(downloaded);
             File withExtractedDir;
             if (downloadedZipMd5hash != null) {
-                final FileExtractor fileExtractor = new FileExtractor(downloaded, downloadedZipMd5hash);
+                final FileExtractor fileExtractor = new FileExtractor(downloaded, Paths.get(MAVEN_TARGET_DIR, downloadedZipMd5hash).toFile());
                 withExtractedDir = fileExtractor.extract();
                 File binDirectory = retrieveBinDirectory(withExtractedDir);
                 useInstallation(binDirectory);

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/FileExtractor.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/FileExtractor.java
@@ -1,0 +1,133 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.logging.Logger;
+import org.arquillian.spacelift.Spacelift;
+import org.arquillian.spacelift.execution.ExecutionException;
+import org.arquillian.spacelift.task.archive.UntarTool;
+import org.arquillian.spacelift.task.archive.UnzipTool;
+
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.DistributionStageImpl.MAVEN_TARGET_DIR;
+
+class FileExtractor {
+
+   private final File fileToExtract;
+   private final File destinationDir;
+   private Logger log = Logger.getLogger(FileExtractor.class.getName());
+
+   FileExtractor(File fileToExtract, String destinationPath) {
+      this.fileToExtract = fileToExtract;
+      this.destinationDir = Paths.get(MAVEN_TARGET_DIR, destinationPath).toFile();
+   }
+
+   private File createExtractionMarkerFile() {
+      try {
+         final File extractionIsProcessing = Paths.get(destinationDir.getPath(), "extractionIsProcessing.tmp").toFile();
+         extractionIsProcessing.createNewFile();
+         extractionIsProcessing.deleteOnExit();
+
+         return extractionIsProcessing;
+      } catch (IOException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   File extract() {
+      File withExtractedDir = checkIfItIsAlreadyExtracted();
+      if (withExtractedDir != null) {
+         return withExtractedDir;
+      }
+      destinationDir.mkdirs();
+      extractFileInDestinationDir();
+      return destinationDir;
+   }
+
+   private void extractFileInDestinationDir() {
+      final File markerFile = createExtractionMarkerFile();
+      final String downloadedPath = fileToExtract.getAbsolutePath();
+
+      try {
+         if (downloadedPath.endsWith(".zip")) {
+            Spacelift.task(fileToExtract, UnzipTool.class).toDir(destinationDir).execute().await();
+         } else if (downloadedPath.endsWith(".tar.gz")) {
+            Spacelift.task(fileToExtract, UntarTool.class).gzip(true).toDir(destinationDir).execute().await();
+         } else if (downloadedPath.endsWith(".tar.bz2")) {
+            Spacelift.task(fileToExtract, UntarTool.class).bzip2(true).toDir(destinationDir).execute().await();
+         } else {
+            throw new IllegalArgumentException(
+               "The distribution " + fileToExtract + " is compressed by unsupported format. "
+                  + "Supported formats are .zip, .tar.gz, .tar.bz2");
+         }
+      } catch (ExecutionException ee) {
+         throw new IllegalStateException(
+            "Something bad happened when the file: " + downloadedPath + " was being extracted. "
+               + "For more information see the stacktrace", ee);
+      }
+      if (!markerFile.delete()) {
+         log.warning("failed to delete temp directory: " + markerFile);
+      }
+      System.out.println(String.format("Resolver: Successfully extracted maven binaries from %s", fileToExtract));
+   }
+
+   private File checkIfItIsAlreadyExtracted() {
+      if (destinationDir.exists() && destinationDir.isDirectory()
+         && destinationDir.list().length > 0 && isExtractionFinished()) {
+         return destinationDir;
+      }
+      return null;
+   }
+
+   private boolean isExtractionFinished() {
+      int count = 0;
+      while (isTempFilePresent() && count < 100) {
+         if (count == 0) {
+            System.out.println(
+               "There is marker file, which means that some other process is already extracting the archive,"
+                  + " waiting for extraction to finish");
+         }
+         System.out.print(".");
+         try {
+            Thread.sleep(100);
+         } catch (InterruptedException e) {
+            log.warning("Problem occurred when the thread was sleeping:\n" + e.getMessage());
+         }
+         count++;
+      }
+      System.out.println();
+      if (count == 99) {
+         try {
+            deleteFileRecursively(destinationDir.toPath());
+         } catch (IOException e) {
+            throw new RuntimeException("Failed to delete directory:" + destinationDir, e);
+         }
+      }
+      return !isTempFilePresent();
+   }
+
+   private boolean isTempFilePresent() {
+      return Paths.get(destinationDir.getPath(), "extractionIsProcessing.tmp").toFile().exists();
+   }
+
+   private void deleteFileRecursively(Path directory) throws IOException {
+      Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+         @Override
+         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            Files.delete(file);
+            return FileVisitResult.CONTINUE;
+         }
+
+         @Override
+         public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            Files.delete(dir);
+            return FileVisitResult.CONTINUE;
+         }
+      });
+   }
+}

--- a/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/FileExtractor.java
+++ b/maven/impl-maven-embedded/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/FileExtractor.java
@@ -101,7 +101,7 @@ class FileExtractor {
          count++;
       }
       System.out.println();
-      if (count == 99) {
+      if (count == 99 && isTempFilePresent()) {
          try {
             deleteFileRecursively(destinationDir.toPath());
          } catch (IOException e) {

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/FileExtractorTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/FileExtractorTestCase.java
@@ -3,6 +3,7 @@ package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -38,7 +39,8 @@ public class FileExtractorTestCase {
       final DistributionStageImpl embeddedMaven = (DistributionStageImpl) EmbeddedMaven.forProject(pathToJarSamplePom);
       final File downloaded = embeddedMaven.download(targetMavenDir, mavenDistribution);
 
-      final FileExtractor fileExtractor = new FileExtractor(downloaded, "948110de4aab290033c23bf4894f7d9a");
+      final FileExtractor fileExtractor =
+         new FileExtractor(downloaded, Paths.get(MAVEN_TARGET_DIR, "948110de4aab290033c23bf4894f7d9a").toFile());
       // multiple threads are extracting
       CountDownLatch firstLatch = new CountDownLatch(1);
       CountDownLatch secondLatch = new CountDownLatch(1);

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/MavenExtractionTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/MavenExtractionTestCase.java
@@ -1,0 +1,77 @@
+package org.jboss.shrinkwrap.resolver.impl.maven.embedded;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.io.FileUtils;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.DistributionStageImpl.MAVEN_TARGET_DIR;
+import static org.jboss.shrinkwrap.resolver.impl.maven.embedded.Utils.pathToJarSamplePom;
+
+public class MavenExtractionTestCase {
+
+   @Rule
+   public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+   private File targetMavenDir = new File(MAVEN_TARGET_DIR);
+
+   @Before
+   public void cleanup() throws IOException {
+      FileUtils.deleteDirectory(targetMavenDir);
+      targetMavenDir.mkdirs();
+   }
+
+   @Test
+   public void testDownloadDefaultMavenAndExtractUsingMultipleThreads() throws IOException, InterruptedException {
+      // download once
+      final URL mavenDistribution =
+         new URL("http://redrockdigimark.com/apachemirror/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz");
+      final DistributionStageImpl embeddedMaven = (DistributionStageImpl) EmbeddedMaven.forProject(pathToJarSamplePom);
+      final File downloaded = embeddedMaven.download(targetMavenDir, mavenDistribution);
+
+      // multiple threads are extracting
+      CountDownLatch firstLatch = new CountDownLatch(1);
+      CountDownLatch secondLatch = new CountDownLatch(1);
+      CountDownLatch stopLatch = new CountDownLatch(3);
+
+      createThreadWithExtract(firstLatch, stopLatch, downloaded, embeddedMaven).start();
+      createThreadWithExtract(secondLatch, stopLatch, downloaded, embeddedMaven).start();
+      createThreadWithExtract(secondLatch, stopLatch, downloaded, embeddedMaven).start();
+
+      firstLatch.countDown();
+      Thread.sleep(50);
+      secondLatch.countDown();
+      stopLatch.await(20, TimeUnit.SECONDS);
+
+      String expMsg = "Resolver: Successfully extracted maven binaries from";
+      Matcher matcher = Pattern.compile(expMsg).matcher(systemOutRule.getLog());
+      assertThat(matcher.find()).as(
+         "The log should contain one occurrence of message \"%s\" but none was found. For more information see the log",
+         expMsg).isTrue();
+   }
+
+   private Thread createThreadWithExtract(final CountDownLatch startLatch, final CountDownLatch stopLatch,
+      final File downloaded, final DistributionStageImpl embeddedMaven) {
+      return new Thread(new Runnable() {
+         @Override
+         public void run() {
+            try {
+               startLatch.await();
+               embeddedMaven.extract(downloaded, "948110de4aab290033c23bf4894f7d9a");
+               stopLatch.countDown();
+            } catch (InterruptedException e) {
+               e.printStackTrace();
+            }
+         }
+      });
+   }
+}


### PR DESCRIPTION
We should avoid synchronize locking on String literal.
Ref - 
https://stackoverflow.com/questions/18206301/effect-of-synchronizedstatic-variable
https://www.javalobby.org/java/forums/t96352.html
http://javarevisited.blogspot.in/2011/04/synchronization-in-java-synchronized.html - Point 20

This fix won't reproduce https://github.com/arquillian/smart-testing/issues/293