### PR TITLE
Fix scope of Embedded Maven API in Dependency Chain

### DIFF
--- a/depchain/pom.xml
+++ b/depchain/pom.xml
@@ -65,7 +65,6 @@
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven-embedded</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>


### PR DESCRIPTION
The documentation suggests to add a dependency to depchain to the
project. The API modules should be in the same scope as depchain.