### PR TITLE
SHRINKRES-291 Updated Gradle Tooling API to support Java 10 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <version.org.apache.maven.plugins_maven-site-plugin>3.5.1</version.org.apache.maven.plugins_maven-site-plugin>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.codehaus.plexus.compiler.javac>2.7</version.org.codehaus.plexus.compiler.javac>
-        <version.gradle-tooling-api>4.0.1</version.gradle-tooling-api>
+        <version.gradle-tooling-api>4.10.2</version.gradle-tooling-api>
         <version.maven.invoker>3.0.0</version.maven.invoker>
         <version.arquillian.spacelift>1.0.2</version.arquillian.spacelift>
 


### PR DESCRIPTION
I am facing following issue as well [SHRINKRES-291](https://issues.jboss.org/browse/SHRINKRES-291) and updated the version of the Gradle Tooling API. I did some local tests with Java 10 and 11. Everything seams to work fine. Let me know, if I can do more.