### PR TITLE
SHRINKRES-296 - update dist to have a newer JDK 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
     - oraclejdk8
     - openjdk7
-dist: precise
+dist: trusty
 branches:
     except:    
         - /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/


### PR DESCRIPTION
which is still compatible with Maven websites

Signed-off-by: Aurélien Pupier <apupier@redhat.com>