### PR TITLE
fix(SHRINKRES-296): update dist for newer JDK7 and fix/workaround maven.home problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
     - oraclejdk8
     - openjdk7
-dist: precise
+dist: trusty
 branches:
     except:    
         - /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/

--- a/maven/impl-maven-embedded/pom.xml
+++ b/maven/impl-maven-embedded/pom.xml
@@ -89,12 +89,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                    <systemProperties>
-                        <property>
-                            <name>version.org.apache.maven.dependency</name>
-                            <value>${version.org.apache.maven}</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <version.org.apache.maven.dependency>${version.org.apache.maven}</version.org.apache.maven.dependency>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Based on #138 by @apupier + fix/workaround for some tests failing with:
```
java.lang.IllegalStateException: Maven application directory was not specified, and ${maven.home} is not provided in the system properties. Please specify at least on of these.
```

`org.jboss.shrinkwrap.resolver.api.maven.embedded.DistributionStage.useLocalInstallation()` (which is used in the affected tests) says:
> Use local Maven installation that is available on your PATH.

I don't see how this is supposed to work. Maven _is_ on the `PATH` and still this doesn't work.