### PR TITLE
fix(SHRINKRES-299): Support "Maven CI Friendly Versions"

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -423,6 +423,14 @@ Path to _settings-security.xml_, that contains encrypted master password for pas
 | +org.apache.maven.offline+ |
 Flag there to work in offline mode.
 
+| +org.apache.maven.flattened-pom-path+ |
+Path to the https://www.mojohaus.org/flatten-maven-plugin/index.html[flattened] variant of a regular _pom.xml_. Default value: _.flattened-pom.xml_
+
+To support https://maven.apache.org/maven-ci-friendly.html["Maven CI Friendly Versions"], the classpath resolution mechanism resolves this path relative
+to the regular _pom.xml_ to look for the preferred flattened variant which contains the interpolated version string instead of just e.g. _${revision}_. 
+
+Example: _target/my-flat-pom.xml_ would resolve to _/foo/bar/target/my-flat-pom.xml_ in case the regular file is located in _/foo/bar/pom.xml_.
+
 | +maven.repo.local+ |
 Path to local repository with cached artifacts. Overrides value defined in any of the _settings.xml_ files.
 

--- a/maven/impl-maven-embedded/pom.xml
+++ b/maven/impl-maven-embedded/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
-            <version>${version.system.rules}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/maven/impl-maven/pom.xml
+++ b/maven/impl-maven/pom.xml
@@ -159,6 +159,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- we need this artifact to test resolution from classpath -->
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/aether/ClassPathScanningTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/aether/ClassPathScanningTestCase.java
@@ -19,10 +19,10 @@ package org.jboss.shrinkwrap.resolver.impl.maven.aether;
 import java.io.File;
 
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -39,22 +39,8 @@ import static org.jboss.shrinkwrap.resolver.impl.maven.aether.ClasspathWorkspace
  */
 public class ClassPathScanningTestCase {
 
-    private static String originalSurefireClasspath;
-
-    @Before
-    public void storeSurefireCP() {
-        originalSurefireClasspath = System.getProperty(SUREFIRE_CLASS_PATH_KEY);
-    }
-
-    @After
-    public void restoreSurefireCP() {
-        if (originalSurefireClasspath == null) {
-            System.clearProperty(SUREFIRE_CLASS_PATH_KEY);
-        }
-        else {
-            System.setProperty(SUREFIRE_CLASS_PATH_KEY, originalSurefireClasspath);
-        }
-    }
+    @Rule
+    public final RestoreSystemProperties restoreSystemPropertiesRule = new RestoreSystemProperties();
 
     @Test
     public void classpathWithDanglingDirs() throws Exception {
@@ -85,8 +71,9 @@ public class ClassPathScanningTestCase {
     /**
      * Tests that {@code ClasspathWorkspaceReader} finds the artifact for a pretty ordinary parent child setup.
      * This also tests that {@code ClasspathWorkspaceReader} does not choke on a missing {@code .flattened-pom.xml}.
+     * <p/>
+     * Test data: {@code src/test/resources/poms/test-ordinary}
      *
-     * @see {@code src/test/resources/poms/test-ordinary}
      * @since SHRINKRES-299
      */
     @Test
@@ -97,8 +84,9 @@ public class ClassPathScanningTestCase {
     /**
      * Tests that {@code ClasspathWorkspaceReader} prefers a {@code .flattened-pom.xml} over the regular {@code pom.xml}
      * to support "Maven CI Friendly Versions".
+     * <p/>
+     * Test data: {@code src/test/resources/poms/test-revision}
      *
-     * @see {@code src/test/resources/poms/test-revision}
      * @since SHRINKRES-299
      */
     @Test
@@ -109,26 +97,17 @@ public class ClassPathScanningTestCase {
     /**
      * Tests that {@code ClasspathWorkspaceReader} prefers a custom {@code target/my-flat-pom.xml} over the regular {@code pom.xml}
      * to support "Maven CI Friendly Versions".
+     * <p/>
+     * Test data: {@code src/test/resources/poms/test-revision-custom}
      *
-     * @see {@code src/test/resources/poms/test-revision-custom}
      * @see ClasspathWorkspaceReader#FLATTENED_POM_PATH_KEY
      * @since SHRINKRES-299
      */
     @Test
     public void mavenCiFriendlyVersion_customFlattenedPom() {
-        final String original = System.getProperty(FLATTENED_POM_PATH_KEY);
-        try {
-            System.setProperty(FLATTENED_POM_PATH_KEY, "target/my-flat-pom.xml");
+        System.setProperty(FLATTENED_POM_PATH_KEY, "target/my-flat-pom.xml");
 
-            testFindArtifactReturnsNotNull("test-revision-custom");
-
-        } finally {
-            if (original != null) {
-                System.setProperty(FLATTENED_POM_PATH_KEY, original);
-            } else {
-                System.clearProperty(FLATTENED_POM_PATH_KEY);
-            }
-        }
+        testFindArtifactReturnsNotNull("test-revision-custom");
     }
 
     private void testFindArtifactReturnsNotNull(String testDirName) {

--- a/maven/impl-maven/src/test/resources/poms/test-ordinary/child/pom.xml
+++ b/maven/impl-maven/src/test/resources/poms/test-ordinary/child/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.shrinkwrap.test</groupId>
+        <artifactId>test-ordinary-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <artifactId>test-ordinary-child</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/maven/impl-maven/src/test/resources/poms/test-ordinary/pom.xml
+++ b/maven/impl-maven/src/test/resources/poms/test-ordinary/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact Configuration -->
+    <groupId>org.jboss.shrinkwrap.test</groupId>
+    <artifactId>test-ordinary-parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+</project>

--- a/maven/impl-maven/src/test/resources/poms/test-revision-custom/child/pom.xml
+++ b/maven/impl-maven/src/test/resources/poms/test-revision-custom/child/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.shrinkwrap.test</groupId>
+        <artifactId>test-revision-custom-parent</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <artifactId>test-revision-custom-child</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/maven/impl-maven/src/test/resources/poms/test-revision-custom/child/target/my-flat-pom.xml
+++ b/maven/impl-maven/src/test/resources/poms/test-revision-custom/child/target/my-flat-pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- this file emulates what flatten-maven-plugin would produce for ../pom.xml
+         with flattenMode resolveCiFriendliesOnly -->
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.shrinkwrap.test</groupId>
+        <artifactId>test-revision-custom-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <groupId>org.jboss.shrinkwrap.test</groupId>
+    <artifactId>test-revision-custom-child</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <revision>1.0.0</revision>
+    </properties>
+
+</project>

--- a/maven/impl-maven/src/test/resources/poms/test-revision-custom/pom.xml
+++ b/maven/impl-maven/src/test/resources/poms/test-revision-custom/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact Configuration -->
+    <groupId>org.jboss.shrinkwrap.test</groupId>
+    <artifactId>test-revision-custom-parent</artifactId>
+    <version>${revision}</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <revision>1.0.0</revision>
+    </properties>
+
+</project>

--- a/maven/impl-maven/src/test/resources/poms/test-revision/child/.flattened-pom.xml
+++ b/maven/impl-maven/src/test/resources/poms/test-revision/child/.flattened-pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- this file emulates what flatten-maven-plugin would produce for the regular pom.xml
+         with flattenMode resolveCiFriendliesOnly -->
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.shrinkwrap.test</groupId>
+        <artifactId>test-revision-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <groupId>org.jboss.shrinkwrap.test</groupId>
+    <artifactId>test-revision-child</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <revision>1.0.0</revision>
+    </properties>
+
+</project>

--- a/maven/impl-maven/src/test/resources/poms/test-revision/child/pom.xml
+++ b/maven/impl-maven/src/test/resources/poms/test-revision/child/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.shrinkwrap.test</groupId>
+        <artifactId>test-revision-parent</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <artifactId>test-revision-child</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/maven/impl-maven/src/test/resources/poms/test-revision/pom.xml
+++ b/maven/impl-maven/src/test/resources/poms/test-revision/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact Configuration -->
+    <groupId>org.jboss.shrinkwrap.test</groupId>
+    <artifactId>test-revision-parent</artifactId>
+    <version>${revision}</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <revision>1.0.0</revision>
+    </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <version.assertj>2.8.0</version.assertj>
         <version.mockito-all>1.10.19</version.mockito-all>
         <version.org.eclipse.jetty>9.2.17.v20160517</version.org.eclipse.jetty>
-        <version.system.rules>1.19.0</version.system.rules>
+        <version.system.rules>1.17.0</version.system.rules>
         <version.awaitility>3.0.0</version.awaitility>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <version.assertj>2.8.0</version.assertj>
         <version.mockito-all>1.10.19</version.mockito-all>
         <version.org.eclipse.jetty>9.2.17.v20160517</version.org.eclipse.jetty>
-        <version.system.rules>1.16.0</version.system.rules>
+        <version.system.rules>1.19.0</version.system.rules>
         <version.awaitility>3.0.0</version.awaitility>
     </properties>
 
@@ -131,6 +131,12 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${version.assertj}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-rules</artifactId>
+                <version>${version.system.rules}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
by preferring the output of flatten-maven-plugin over the regular pom.xml
which just has a "useless" placeholder like ${revision} as the version.

**Some notes about this approach:**

There is already a TODO note in `ClasspathWorkspaceReader.createFoundArtifact(File)` about whether it would be better to load the pom (and its parents) "properly" via Maven.
This might have also been a possible solution, but I am not sure whether such a heavy lifting should be done there.
The note regarding "cycle in graph reconstruction" also scared me off a bit, to be honest.
Furthermore, a `revision` property does not need to defined in the pom at all (AFAIK). It can also be passed in via `-Drevision=...`. Parsing the entire Maven model would not help in that case.

My first approach was to completely swap the `FileInfo`:
```java
    private FileInfo createPomFileInfo(final File childFile) {

        // assuming that directory entry on classpath is target/classes directory, we need
        // to go two directories up in the structure and grab a pom.xml file from there
        // SHRINKRES-299: we prefer a "flattened" pom.xml written by flatten-maven-plugin
        File parent = childFile.getParentFile();
        if (parent != null) {
            parent = parent.getParentFile();
            if (parent != null) {
                FileInfo fileInfo = new FileInfo(new File(parent, flattenedPomPath));
                if (!fileInfo.isFile()) {
                    fileInfo = new FileInfo(new File(parent, "pom.xml"));
                }
                return fileInfo;
            }
        }

        return null;
    }
```
but this caused problems in `MavenResolvedArtifactImpl.artifactToFile(Artifact)` as the name of the artifact file would then not be `pom.xml` anymore but `.flattened-pom.xml` or something else. I would have needed to re-evaluate the new system property there. Or maybe `org.eclipse.aether.artifact.Artifact.getProperty(String, String)` could have been used (`ClasspathWorkspaceReader` might be able to set a property that signals "this artifact is a pom!").
I dropped that approach because it did not feel right.

And why did I introduce a new system property?
The name an the output directory of the flattened pom are completely configurable, see: https://www.mojohaus.org/flatten-maven-plugin/flatten-mojo.html#flattenedPomFilename
Also there's a ticket about changing the default output folder/name: https://github.com/mojohaus/flatten-maven-plugin/issues/53
So, with the system property people can adapt `shrinkwrap-resolver` to their flatten config.