### PR TITLE
chore: update system-rules to 1.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <version.assertj>2.8.0</version.assertj>
         <version.mockito-all>1.10.19</version.mockito-all>
         <version.org.eclipse.jetty>9.2.17.v20160517</version.org.eclipse.jetty>
-        <version.system.rules>1.17.0</version.system.rules>
+        <version.system.rules>1.19.0</version.system.rules>
         <version.awaitility>3.0.0</version.awaitility>
     </properties>
 


### PR DESCRIPTION
Although `system-rules 1.19.0` being released already, #142 upgraded from `1.16.0` to just `1.17.0` due to a test failure on JDK7 with `> 1.17.0`: https://github.com/shrinkwrap/resolver/pull/142#issuecomment-568019712

Later, that problem could not be reproduced anymore, see #143. 

So it seems we can update right away.