### PR TITLE
chore: bring back jdk7 Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
     - oraclejdk8
-    - openjdk8
+    - openjdk7
 dist: trusty
 branches:
     except:    

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <!-- Properties -->
     <properties>
         <!-- Java target is 1.7 -->
+        <!-- Make sure to adjust jdk version specific profiles when bumping this version -->
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.argument.target>1.7</maven.compiler.argument.target>
@@ -42,6 +43,8 @@
         <version.arquillian.spacelift>1.0.2</version.arquillian.spacelift>
 
         <version.maven.shade.plugin>3.0.0</version.maven.shade.plugin>
+
+        <version.animal-sniffer-maven-plugin>1.18</version.animal-sniffer-maven-plugin>
 
         <!-- Versions of test dependencies -->
         <version.junit_junit>4.12</version.junit_junit>
@@ -340,5 +343,50 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <!-- Special JDK version handling, see also:
+         https://github.com/shrinkwrap/resolver/commit/2018e1bb704a0e4593f65ca69fd955f50eb58bfb#commitcomment-36651197 -->
+    <profiles>
+        <profile>
+            <id>jdk7</id>
+            <activation>
+                <jdk>1.7</jdk>
+            </activation>
+            <properties>
+                <version.checkstyle>6.19</version.checkstyle>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk8+</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <version>${version.animal-sniffer-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>check-java-version-compatibility</id>
+                                <phase>test</phase>
+                                <goals>
+                                   <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <signature>
+                                        <groupId>org.codehaus.mojo.signature</groupId>
+                                        <artifactId>java17</artifactId>
+                                        <version>1.0</version>
+                                    </signature>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
As discussed here: https://github.com/shrinkwrap/resolver/commit/2018e1bb704a0e4593f65ca69fd955f50eb58bfb#commitcomment-36651197