### PR TITLE
SHRINKRES-295 add testing on Java 11 to support JDK's with java module system  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ atlassian-ide-plugin.xml
 
 !maven/impl-maven/src/test/resources/repository/org/jboss/shrinkwrap/test/test-pom/1.0.0/target
 !maven/impl-maven/src/test/resources/repository/org/jboss/shrinkwrap/test/test-war-with-resources/1.0.0/target
+*.factorypath
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
     - oraclejdk8
     - openjdk7
+    - openjdk11
 dist: trusty
 branches:
     except:    

--- a/maven/impl-maven-archive/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/archive/plugins/CompilerPluginConfiguration.java
+++ b/maven/impl-maven-archive/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/archive/plugins/CompilerPluginConfiguration.java
@@ -52,9 +52,9 @@ public class CompilerPluginConfiguration {
         Properties properties = pomFile.getProperties();
         this.verbose = ConfigurationUtils.valueAsBoolean(rawValues, new Key("verbose"), false);
         this.sourceVersion = ConfigurationUtils.valueAsString(rawValues, new Key("source"),
-            properties.getProperty("maven.compiler.source", "1.5"));
+            properties.getProperty("maven.compiler.source", "1.6"));
         this.targetVersion = ConfigurationUtils.valueAsString(rawValues, new Key("target"),
-            properties.getProperty("maven.compiler.target", "1.5"));
+            properties.getProperty("maven.compiler.target", "1.6"));
         this.encoding = ConfigurationUtils.valueAsString(rawValues,
             new Key("encoding"),
             properties.getProperty("project.build.sourceEncoding", ""));

--- a/maven/impl-maven-embedded/src/it/jar-sample/pom.xml
+++ b/maven/impl-maven-embedded/src/it/jar-sample/pom.xml
@@ -33,6 +33,11 @@
     </dependencies>
 
 
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
     <profiles>
         <profile>
             <id>test-classes</id>

--- a/maven/impl-maven-embedded/src/it/multi-module-sample/pom.xml
+++ b/maven/impl-maven-embedded/src/it/multi-module-sample/pom.xml
@@ -13,6 +13,11 @@
         Integration test project for running Maven builds and retrieving information and archives from the built project
     </description>
 
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
     <profiles>
         <profile>
             <id>modules</id>

--- a/maven/impl-maven-embedded/src/it/war-sample/pom.xml
+++ b/maven/impl-maven-embedded/src/it/war-sample/pom.xml
@@ -14,6 +14,11 @@
     </description>
 
 
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenForMultiModuleSampleTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenForMultiModuleSampleTestCase.java
@@ -35,7 +35,7 @@ public class InvokerEquippedEmbeddedMavenForMultiModuleSampleTestCase {
     public final TestWorkDirRule workDirRule = new TestWorkDirRule();
 
     @Test
-    public void testMultiModuleSampleBuildWithMaven305() {
+    public void testMultiModuleSampleBuildWithMaven363() {
         InvocationRequest request = new DefaultInvocationRequest();
         Invoker invoker = new DefaultInvoker();
 
@@ -55,11 +55,11 @@ public class InvokerEquippedEmbeddedMavenForMultiModuleSampleTestCase {
 
         BuiltProject builtProject = EmbeddedMaven
             .withMavenInvokerSet(request, invoker)
-            .useMaven3Version("3.0.5")
+            .useMaven3Version("3.6.3")
             .build();
         builtProject.setMavenLog(logBuffer.toString());
 
-        verifyMavenVersion(builtProject, "3.0.5");
+        verifyMavenVersion(builtProject, "3.6.3");
         verifyMultiModuleSample(builtProject, true);
     }
 

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenForWarSampleTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/invoker/equipped/InvokerEquippedEmbeddedMavenForWarSampleTestCase.java
@@ -31,7 +31,7 @@ public class InvokerEquippedEmbeddedMavenForWarSampleTestCase {
     public final TestWorkDirRule workDirRule = new TestWorkDirRule();
 
     @Test
-    public void testWarSampleBuildWithMaven310() {
+    public void testWarSampleBuildWithMaven363() {
         InvocationRequest request = new DefaultInvocationRequest();
         Invoker invoker = new DefaultInvoker();
 
@@ -49,12 +49,12 @@ public class InvokerEquippedEmbeddedMavenForWarSampleTestCase {
 
         BuiltProject builtProject = EmbeddedMaven
             .withMavenInvokerSet(request, invoker)
-            .useMaven3Version("3.1.0")
+            .useMaven3Version("3.6.3")
             .build();
         builtProject.setMavenLog(logBuffer.toString());
 
         verifyWarSampleWithSources(builtProject);
-        verifyMavenVersion(builtProject, "3.1.0");
+        verifyMavenVersion(builtProject, "3.6.3");
     }
 
     @Test(expected = IllegalStateException.class)

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenForMultiModuleSampleTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenForMultiModuleSampleTestCase.java
@@ -24,17 +24,17 @@ public class PomEquippedEmbeddedMavenForMultiModuleSampleTestCase {
     public final TestWorkDirRule workDirRule = new TestWorkDirRule();
 
     @Test
-    public void testMultiModuleSampleBuildWithMaven305() {
+    public void testMultiModuleSampleBuildWithMaven363() {
         BuiltProject builtProject = EmbeddedMaven
             .forProject(workDirRule.prepareProject(pathToMultiModulePom))
-            .useMaven3Version("3.0.5")
+            .useMaven3Version("3.6.3")
             .setGoals("install")
             .addProperty(multiModuleactivateModulesParamKey, multiModuleactivateModulesParamValue)
             .addProperty(archiveNameModuleTwoParamKey, archiveNameModuleTwoParamValue)
             .setShowVersion(true)
             .build();
 
-        verifyMavenVersion(builtProject, "3.0.5");
+        verifyMavenVersion(builtProject, "3.6.3");
         verifyMultiModuleSample(builtProject, true);
     }
 

--- a/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenForWarSampleTestCase.java
+++ b/maven/impl-maven-embedded/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/embedded/pom/equipped/PomEquippedEmbeddedMavenForWarSampleTestCase.java
@@ -24,13 +24,13 @@ public class PomEquippedEmbeddedMavenForWarSampleTestCase {
 
         BuiltProject builtProject = EmbeddedMaven
             .forProject(workDirRule.prepareProject(pathToWarSamplePom))
-            .useMaven3Version("3.1.0")
+            .useMaven3Version("3.6.3")
             .setGoals("clean", "package", "source:jar")
             .setShowVersion(true)
             .build();
 
         verifyWarSampleWithSources(builtProject);
-        verifyMavenVersion(builtProject, "3.1.0");
+        verifyMavenVersion(builtProject, "3.6.3");
     }
 
     @Test(expected = IllegalStateException.class)

--- a/maven/impl-maven-integration-tests/jar-sample/pom.xml
+++ b/maven/impl-maven-integration-tests/jar-sample/pom.xml
@@ -18,6 +18,11 @@
     <packaging>jar</packaging>
     <name>ShrinkWrap Resolver Maven Implementation Tests: Jar Sample</name>
 
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <!-- org.jboss.shrinkwrap -->
         <dependency>

--- a/maven/impl-maven/src/test/resources/repository/org/jboss/shrinkwrap/test/test-system-scope/9.0.0/test-system-scope-9.0.0.pom
+++ b/maven/impl-maven/src/test/resources/repository/org/jboss/shrinkwrap/test/test-system-scope/9.0.0/test-system-scope-9.0.0.pom
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact Configuration -->
+    <groupId>org.jboss.shrinkwrap.test</groupId>
+    <artifactId>test-system-scope</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <build>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>jdk.internal</groupId>
+            <artifactId>jrt-fs</artifactId>
+            <version>11.0</version>
+            <scope>system</scope>
+            <systemPath>${java.home}/lib/jrt-fs.jar</systemPath>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/maven/impl-maven/src/test/resources/repository/org/jboss/shrinkwrap/test/test-system-scope/maven-metadata-local.xml
+++ b/maven/impl-maven/src/test/resources/repository/org/jboss/shrinkwrap/test/test-system-scope/maven-metadata-local.xml
@@ -3,9 +3,10 @@
   <groupId>org.jboss.shrinkwrap.test</groupId>
   <artifactId>test-system-scope</artifactId>
   <versioning>
-    <release>1.0.0</release>
+    <release>9.0.0</release>
     <versions>
       <version>1.0.0</version>
+      <version>9.0.0</version>
     </versions>
     <lastUpdated>20140920183336</lastUpdated>
   </versioning>

--- a/maven/maven-plugin/src/it/context-propagation/pom.xml
+++ b/maven/maven-plugin/src/it/context-propagation/pom.xml
@@ -23,6 +23,12 @@
         </dependency>
     </dependencies>
 
+
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
         <version.org.apache.maven.plugins_maven-site-plugin>3.5.1</version.org.apache.maven.plugins_maven-site-plugin>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.codehaus.plexus.compiler.javac>2.7</version.org.codehaus.plexus.compiler.javac>
-        <version.gradle-tooling-api>4.0.1</version.gradle-tooling-api>
-        <version.maven.invoker>3.0.0</version.maven.invoker>
+        <version.gradle-tooling-api>6.1.1</version.gradle-tooling-api>
+        <version.maven.invoker>3.0.1</version.maven.invoker>
         <version.arquillian.spacelift>1.0.2</version.arquillian.spacelift>
 
         <version.maven.shade.plugin>3.0.0</version.maven.shade.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
this is adding Java 11 testing to the test matrix but it really is about making resolver test suite work on Java 9 and up where java module system was introduced.