### PR TITLE
chore(travis): enables batch mode for mvn build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ branches:
 install:
     - true
 script:
-    - ./mvnw clean install
+    - ./mvnw -B clean install


### PR DESCRIPTION
would be great to run with `-fae` too but lets at least save some scrolling when looking at failing travis build