### PR TITLE
backport some important fixes to the 2.2.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 jdk:
     - oraclejdk8
-    - oraclejdk7
+    - openjdk7
+dist: trusty
 branches:
     except:    
         - /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/

--- a/impl-gradle-embedded-archive/pom.xml
+++ b/impl-gradle-embedded-archive/pom.xml
@@ -75,7 +75,7 @@
         <repository>
             <id>jfrog</id>
             <name>jfrog</name>
-            <url>http://repo.jfrog.org/artifactory/repo</url>
+            <url>https://repo.jfrog.org/artifactory/gradle</url>
         </repository>
     </repositories>
 </project>

--- a/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
+++ b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
@@ -108,7 +108,7 @@ public class MavenWorkingSessionImpl extends ConfigurableMavenWorkingSessionImpl
     private static final String MAVEN_CENTRAL_NAME = "central";
     // creates a link to Maven Central Repository
     private static final RemoteRepository MAVEN_CENTRAL = new RemoteRepository.Builder(MAVEN_CENTRAL_NAME, "default",
-            "http://repo1.maven.org/maven2").build();
+            "https://repo1.maven.org/maven2").build();
 
     private Model model;
 


### PR DESCRIPTION
Hi @MatousJobanek @bartoszmajsak, I'm not sure who's in charge of ShrinkWrap Resolver these days, but I'd like this HTTP -> HTTPS fix to be backported to the 2.2.x branch, because updating to latest 3.1.4 in Thorntail proves very difficult (I found one breaking change, but even after fixing that, things still don't work as they should).

The other commit, JFrog repo URL change, is necessary to make the project build. I found that `mvn clean install` works fine with Maven 3.3.9; when using Maven 3.6.3, some of the Maven plugin tests fail because of binary incompatible change in Aether or something like that. I think that's probably expected, considering this comment in `/pom.xml`: `Aether version must be the same as used in Maven in order for plugin to work`.

I think it should be perfectly possible to do a release with Maven 3.3.9; I for one still keep that version locally. WDYT?