### PR TITLE
new feateure: allow additional packaging type to set extension

### DIFF
--- a/maven/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/PackagingType.java
+++ b/maven/api-maven/src/main/java/org/jboss/shrinkwrap/resolver/api/maven/PackagingType.java
@@ -106,12 +106,20 @@ public class PackagingType {
      * Thrown if typeName is {@code null} or empty
      */
     public static PackagingType of(String typeName) throws IllegalArgumentException {
+        return of(typeName, typeName, "");
+    }
+
+    public static PackagingType of(String typeName, String extension) throws IllegalArgumentException {
+        return of(typeName, extension, "");
+    }
+
+    public static PackagingType of(String typeName, String extension, String classifier) throws IllegalArgumentException {
         PackagingType packagingType = fromCache(typeName);
         if (packagingType != null){
             return packagingType;
         }
         // this will cause packaging object to register into cache
-        return new PackagingType(typeName);
+        return new PackagingType(typeName, extension == null ? typeName : extension, classifier == null ? "" : classifier);
     }
 
     /**

--- a/maven/api-maven/src/test/java/org/jboss/shrinkwrap/resolver/api/maven/PackagingTypeTestCase.java
+++ b/maven/api-maven/src/test/java/org/jboss/shrinkwrap/resolver/api/maven/PackagingTypeTestCase.java
@@ -72,4 +72,17 @@ public class PackagingTypeTestCase {
         Assert.assertEquals("random", PackagingType.of("random").toString());
     }
 
+    @Test
+    public void bundle() {
+        final PackagingType packagingType = PackagingType.of("bundle", "jar");
+        Assert.assertEquals("bundle", packagingType.toString());
+        Assert.assertEquals("jar", packagingType.getExtension());
+        Assert.assertEquals("", packagingType.getClassifier());
+
+        final PackagingType packagingType2 = PackagingType.of("bundle2", null, null);
+        Assert.assertEquals("bundle2", packagingType2.toString());
+        Assert.assertEquals("bundle2", packagingType2.getExtension());
+        Assert.assertEquals("", packagingType2.getClassifier());
+    }
+
 }


### PR DESCRIPTION
Proposed feature would allow one to create PackagingType with extension (and classifier).

```
PackagingType.of("bundle", "jar")
PackagingType.of("bundle", "jar", "some-classifier")
```

Why this is needed? For example
maven-bundle-plugin (org.apache.felix) needs packaging to be set as "bundle" and it builds artifact with extension "jar". Without proposed feature built artifact would have extension "bundle" (same as packaging type)
