### PR TITLE
Upgrade gradle tooling dependecy for Java 11 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <version.org.apache.maven.plugins_maven-site-plugin>3.5.1</version.org.apache.maven.plugins_maven-site-plugin>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.codehaus.plexus.compiler.javac>2.7</version.org.codehaus.plexus.compiler.javac>
-        <version.gradle-tooling-api>4.0.1</version.gradle-tooling-api>
+        <version.gradle-tooling-api>4.10.3</version.gradle-tooling-api>
         <version.maven.invoker>3.0.0</version.maven.invoker>
         <version.arquillian.spacelift>1.0.2</version.arquillian.spacelift>
 


### PR DESCRIPTION
Also set JavaDoc generation to source level 1.8. Otherwise it crashes with a package vs. modules error.