### PR TITLE
Use Plexus container to grab Maven components

### DIFF
--- a/maven/impl-maven/pom.xml
+++ b/maven/impl-maven/pom.xml
@@ -42,6 +42,20 @@
 
         <!-- External Projects -->
 
+        <dependency>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.plexus</artifactId>
+            <version>0.3.5</version> <!-- Note: older version imported from Maven parent, but use latest -->
+        </dependency>
+        <!-- Sisu Inject/Plexus leaves to user to "bring in" Guice that is really a runtime dep only! -->
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>no_aop</classifier>
+            <version>4.2.3</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- org.apache.maven -->
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/internal/SettingsXmlProfileSelector.java
+++ b/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/internal/SettingsXmlProfileSelector.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.maven.model.Profile;
 import org.apache.maven.model.building.ModelProblemCollector;
-import org.apache.maven.model.path.DefaultPathTranslator;
 import org.apache.maven.model.profile.ProfileActivationContext;
 import org.apache.maven.model.profile.ProfileSelector;
 import org.apache.maven.model.profile.activation.FileProfileActivator;
@@ -43,11 +42,13 @@ public class SettingsXmlProfileSelector implements ProfileSelector {
 
     private final List<ProfileActivator> activators;
 
-    public SettingsXmlProfileSelector() {
-        this.activators = new ArrayList<ProfileActivator>();
-        activators.addAll(Arrays.asList(new JdkVersionProfileActivator(), new PropertyProfileActivator(),
-            new OperatingSystemProfileActivator(),
-            new FileProfileActivator().setPathTranslator(new DefaultPathTranslator())));
+    public SettingsXmlProfileSelector( final JdkVersionProfileActivator jdkVersionProfileActivator,
+                                       final PropertyProfileActivator propertyProfileActivator,
+                                       final OperatingSystemProfileActivator operatingSystemProfileActivator,
+                                       final FileProfileActivator fileProfileActivator ) {
+        this.activators = new ArrayList<>();
+        activators.addAll(Arrays.asList(jdkVersionProfileActivator, propertyProfileActivator,
+                operatingSystemProfileActivator, fileProfileActivator));
     }
 
     @Override


### PR DESCRIPTION
As one of the reasons to container is exactly to protect
you (client code) for breakage that is not gonna happen
with components, as instantiation is done by container.

This code is now fully compatible with ALL line of Maven
versions released so far (from lowest that shrinkwrap
resolver requires of course).