### PR TITLE
SHRINKRES-308 Gradle cannot be downloaded from https://repo.jfrog.org/artifactory/gradle

### DIFF
--- a/gradle/impl-gradle/pom.xml
+++ b/gradle/impl-gradle/pom.xml
@@ -69,7 +69,7 @@
         <repository>
             <id>jfrog</id>
             <name>jfrog</name>
-            <url>https://repo.jfrog.org/artifactory/gradle</url>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SHRINKRES-308