### PR TITLE
Fixed links to resolver repository in BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -26,9 +26,9 @@
 
   <!-- SCM -->
   <scm>
-    <connection>scm:git:git://github.com/shrinkwrap/shrinkwrap.git</connection>
-    <developerConnection>scm:git:git@github.com:shrinkwrap/shrinkwrap.git</developerConnection>
-    <url>https://github.com/shrinkwrap/shrinkwrap</url>
+    <connection>scm:git:git://github.com/shrinkwrap/resolver.git</connection>
+    <developerConnection>scm:git:git@github.com:shrinkwrap/resolver.git</developerConnection>
+    <url>https://github.com/shrinkwrap/resolver</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
The "org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-bom" links to the shrinkwrap repository. I assume that this is the reason why dependabot showed the commit history of the shrinkwrap repository instead of the resolver changelog, see https://github.com/arquillian/arquillian-extension-warp/pull/142 for a sample.