### PR TITLE
[SHRINKRES-305] [SHRINKRES-282] Resolve just a pom.xml

### DIFF
--- a/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
+++ b/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
@@ -241,7 +241,7 @@ public class MavenWorkingSessionImpl extends ConfigurableMavenWorkingSessionImpl
         this.getDependenciesForResolution().clear();
 
         // apply post filtering
-        return PostResolutionFilterApplicator.postFilter(resolvedArtifacts);
+        return PostResolutionFilter.filter(resolvedArtifacts, depsForResolution, strategy);
     }
 
     @Override

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/AsMavenResolvedArtifactTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/AsMavenResolvedArtifactTestCase.java
@@ -109,7 +109,7 @@ public class AsMavenResolvedArtifactTestCase {
     }
 
     /**
-     * Poms are filtered out.
+     * Poms are not filtered out when using the withoutTransitivity().
      */
     @Test
     public void emptyResolvedListFromPom() {
@@ -125,7 +125,7 @@ public class AsMavenResolvedArtifactTestCase {
                 .asResolvedArtifact();
 
         // then
-        assertEquals("resolved artifact infos list should be empty for pom dependency", 0, resolvedArtifactInfos.length);
+        assertEquals("resolved artifact infos list should be empty for pom dependency", 1, resolvedArtifactInfos.length);
     }
 
     /**

--- a/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/PomDependenciesUnitTestCase.java
+++ b/maven/impl-maven/src/test/java/org/jboss/shrinkwrap/resolver/impl/maven/integration/PomDependenciesUnitTestCase.java
@@ -277,4 +277,37 @@ public class PomDependenciesUnitTestCase {
         new ValidationUtil("test-managed-dependency", "test-deps-b", "test-deps-k", "test-deps-l").validate(files);
     }
 
+    /**
+     * Tests whether the POM is filtered if multiple dependencies should be resolved using the Non-transitivity strategy.
+     */
+    @Test
+    public void testPomResolutionInMultipleDependencies() {
+        File[] file = Maven.resolver().loadPomFromFile("target/poms/test-remote-child.xml")
+                .resolve("org.jboss.shrinkwrap.test:test-deps-c:pom:1.0.0", "org.jboss.shrinkwrap.test:test-deps-a:pom:1.0.0").withoutTransitivity().asFile();
+
+        new ValidationUtil("test-deps-c-1.0.0.pom", "test-deps-a-1.0.0.pom").validate(file);
+    }
+
+    /**
+     * Tests whether the POM is filtered if a single dependency should be resolved using the Non-transitivity strategy.
+     */
+    @Test
+    public void testPomResolutionInSingleDependency() {
+        File[] file = Maven.resolver().loadPomFromFile("target/poms/test-remote-child.xml")
+                .resolve("org.jboss.shrinkwrap.test:test-deps-c:pom:1.0.0").withoutTransitivity().asFile();
+
+        new ValidationUtil("test-deps-c-1.0.0.pom").validate(file);
+    }
+
+    /**
+     * Tests whether the POM is filtered out using the Transitivity strategy.
+     */
+    @Test (expected = AssertionError.class)
+    public void testPomResolutionWithTransitivity() {
+        File[] file = Maven.resolver().loadPomFromFile("target/poms/test-remote-child.xml")
+                .resolve("org.jboss.shrinkwrap.test:test-deps-c:pom:1.0.0").withTransitivity().asFile();
+
+        new ValidationUtil("test-deps-c-1.0.0.pom").validate(file);
+    }
+
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SHRINKRES-282
https://issues.redhat.com/browse/SHRINKRES-305

POMs now can be resolved by specifying pom in the resolution form and using withoutTransitivity