### PR TITLE
chore: replace directories in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: maven
-    directories:
-      - "**/*"
+    directory: "/"
     schedule:
       interval: daily
       time: "08:00"
       timezone: Europe/Prague
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Due to an error in Dependabot we got multiple duplicate PRs for a single dependency. We have to remove the directories for now and watch whether the fix has been provided

https://github.com/dependabot/dependabot-core/issues/10415
https://github.com/dependabot/dependabot-core/issues/10340