### PR TITLE
[SHRINKRES-354] update to keep track of changes in maven 4-rc-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ ShrinkWrap Resolvers allows you to override any programmatic configuration via S
 - `maven.legacyLocalRepo`: Flag whether to ignore origin tracking for artifacts present in local repository.
 - `org.jboss.shrinkwrap.resolver.maven.skipCompilation`: Flag to skip compilation of resolved artifacts (true/false) - default is false.
 - `org.jboss.shrinkwrap.resolver.maven.disableProjectLocal`: Flag to disable Maven 4 project-local repository (true/false) - default is false.
+- `org.jboss.shrinkwrap.resolver.maven.ignoreDecryptionProblems`: Flag to ignore decryption problems in settings-security*.xml files (true/false) - default is false.
 
 
 ## Embedded Maven

--- a/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
+++ b/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
@@ -244,9 +244,12 @@ public class MavenWorkingSessionImpl extends ConfigurableMavenWorkingSessionImpl
                                                String artifactId, String version,
                                                Set<MavenDependency> additionalDependencies) {
         Path directory = projectLocalRepository.resolve(groupId).resolve(artifactId).resolve(version);
-        File consumerPom = directory.resolve(toVersionedArtifact(artifactId, version) + "-consumer.pom").toFile();
-        if (consumerPom.exists()) {
-            Set<MavenDependency> transitiveDependencies = loadPomFromFile(consumerPom).getParsedPomFile().getDependencies();
+        File pom = directory.resolve(toVersionedArtifact(artifactId, version) + "-consumer.pom").toFile();
+        if (!pom.exists()) {
+            pom = directory.resolve(toVersionedArtifact(artifactId, version) + ".pom").toFile();
+        }
+        if (pom.exists()) {
+            Set<MavenDependency> transitiveDependencies = loadPomFromFile(pom).getParsedPomFile().getDependencies();
             transitiveDependencies.removeAll(additionalDependencies);
             if (!transitiveDependencies.isEmpty()) {
                 additionalDependencies.addAll(transitiveDependencies);

--- a/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenSettingsBuilder.java
+++ b/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenSettingsBuilder.java
@@ -229,7 +229,8 @@ public class MavenSettingsBuilder {
         SettingsDecryptionRequest request = new DefaultSettingsDecryptionRequest(settings);
         SettingsDecryptionResult result = decrypter.decrypt(request);
 
-        if (!result.getProblems().isEmpty()) {
+        if (!result.getProblems().isEmpty()
+                && !Boolean.getBoolean("org.jboss.shrinkwrap.resolver.maven.ignoreDecryptionProblems")) {
             StringBuilder sb = new StringBuilder("Found ").append(result.getProblems().size())
                     .append(" problems while trying to decrypt settings configuration.");
 


### PR DESCRIPTION
Maven team has changed how project-local pom is organized slightly.
`-consumer.pom` files have been renamed to just `.pom`
This PR fixes problems associated with that change
Added `org.jboss.shrinkwrap.resolver.maven.ignoreDecryptionProblems` system property
to ignore security issues since maven 4 completely changed the format of encrypted passwords