### PR TITLE
chore: keep updated with maven 4 rc-2 consumer pom changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The project primarily focuses on supporting Maven-based repository structures, e
 - **Maven**: Version 3.3.9 or newer.
 - **Gradle**: Version 3 or newer.
 
+## Maven 4 Feature:
+- Add the following to your ~/.m2/maven.properties in order to run tests from
+within your project's submodules: `maven.consumer.pom=true` or add `-Dmaven.consumer.pom=true` to your Maven package command line.
 
 ## Adding ShrinkWrap Resolvers to Your Project
 

--- a/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenRepositorySystem.java
+++ b/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenRepositorySystem.java
@@ -76,7 +76,7 @@ public class MavenRepositorySystem {
      * @return A working session spawned from the repository system.
      */
     public DefaultRepositorySystemSession getSession(final Settings settings, boolean legacyLocalRepository) {
-        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(context.repositorySystemSession());
 
         MavenManagerBuilder builder = new MavenManagerBuilder(context.repositorySystem(), settings);
 


### PR DESCRIPTION
Maven release 4.0.0-rc-2 changed how consumer POM is generated.
new option `maven.consumer.pom=true` is necessary to make ShrinkWrap work prior to the PR,
and take full advantage of maven 4 features in the future.
