### PR TITLE
Fix resolver with Maven 4 by @gnodet

### DIFF
--- a/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
+++ b/maven/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/MavenWorkingSessionImpl.java
@@ -45,6 +45,7 @@ import org.apache.maven.model.building.DefaultModelBuilderFactory;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.model.building.ModelBuildingException;
+import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.model.building.ModelProblem;
 import org.eclipse.aether.artifact.Artifact;
@@ -160,7 +161,9 @@ public class MavenWorkingSessionImpl extends ConfigurableMavenWorkingSessionImpl
         final DefaultModelBuildingRequest request = new DefaultModelBuildingRequest()
                 .setSystemProperties(SecurityActions.getProperties()).setProfiles(this.getSettingsDefinedProfiles())
                 .setPomFile(pomFile).setActiveProfileIds(SettingsXmlProfileSelector.explicitlyActivatedProfiles(profiles))
-                .setInactiveProfileIds(SettingsXmlProfileSelector.explicitlyDisabledProfiles(profiles));
+                .setInactiveProfileIds(SettingsXmlProfileSelector.explicitlyDisabledProfiles(profiles))
+                .setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL)
+                .setProcessPlugins(false);
 
         if (userProperties != null){
             request.setUserProperties(userProperties);


### PR DESCRIPTION
Set validation level to `VALIDATION_LEVEL_MINIMAL` and do not process plugins.
Improves Maven 4 compatibility by @gnodet 

This PR is the same as #378 and is only here to kick off tests