### PR TITLE
Fix shrinkwrap-resolver-bom leaking artifacts NOT produced by this pr…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -15,13 +15,13 @@
   <name>ShrinkWrap Resolver Bill of Materials</name>
   <description>Centralized dependencyManagement for the ShrinkWrap Resolver Project</description>
   <url>http://www.jboss.org/shrinkwrap</url>
-  
+
   <!-- Licenses -->
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license> 
+    </license>
   </licenses>
 
   <!-- SCM -->
@@ -43,16 +43,12 @@
 
   <!-- Properties -->
   <properties>
-
     <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
-    <version.org.apache.maven>3.9.9</version.org.apache.maven>
-
   </properties>
 
   <!-- Dependency Management -->
   <dependencyManagement>
-  
     <dependencies>
       <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
@@ -133,19 +129,9 @@
         <artifactId>shrinkwrap-resolver-impl-maven-embedded</artifactId>
         <version>${project.version}</version>
       </dependency>
-
-       <!-- Maven BOM -->
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven</artifactId>
-        <version>${version.org.apache.maven}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
     </dependencies>
-  
   </dependencyManagement>
-  
+
   <build>
     <pluginManagement>
       <plugins>
@@ -153,7 +139,7 @@
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
             <pushChanges>false</pushChanges>
-            <localCheckout>true</localCheckout> 
+            <localCheckout>true</localCheckout>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
…oject violating BOM requirements

> The root of the project is the BOM POM. It defines the versions of all the artifacts that will be **created** in the library. Other projects that wish to use the library should import this POM into the dependencyManagement section of their POM.

And the org.apache.maven:maven is not created by this library and thus must not be in this bom as that leaks a lot of unrelated definitions.

