### PR TITLE
Add test scope to hamcrest dependency

### DIFF
--- a/maven/impl-maven-archive/pom.xml
+++ b/maven/impl-maven-archive/pom.xml
@@ -97,6 +97,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Hamcrest isn't declared as test dependency, which causes it to be pulled into a shrinkwrap archive.